### PR TITLE
Add IBAN validator tests for various countries

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 | ⚙️ **Enterprise Ready** | Production-grade validation trusted by financial institutions |
 | 🔒 **Privacy First** | All validations run locally — your data never leaves your servers |
 | ⚡ **Lightning Fast** | Optimized algorithms with zero network latency |
-| 🌍 **Global Coverage** | 70+ countries across 6 continents |
+| 🌍 **Global Coverage** | 80+ countries across 6 continents |
 | 🧩 **Easy Integration** | FluentValidation support, dependency injection ready |
 
 ---
@@ -122,15 +122,33 @@ dotnet add package Finova.Extensions.FluentValidation
 |--------|---------|--------|--------------|--------------|
 | **North America** | 🇺🇸 USA | EIN ✓ | — | ABA Routing ✓ |
 | | 🇨🇦 Canada | BN ✓ | — | Transit Number ✓ |
-| **South America** | 🇧🇷 Brazil | CNPJ/CPF ✓ | — | — |
+| **Caribbean/Central America** | 🇨🇷 Costa Rica | — | IBAN ✓ | — |
+| | 🇩🇴 Dominican Republic | — | IBAN ✓ | — |
+| | 🇸🇻 El Salvador | — | IBAN ✓ | — |
+| | 🇬🇹 Guatemala | — | IBAN ✓ | — |
+| | 🇻🇬 Virgin Islands (British) | — | IBAN ✓ | — |
+| **South America** | 🇧🇷 Brazil | CNPJ/CPF ✓ | IBAN ✓ | — |
 | | 🇲🇽 Mexico | RFC ✓ | — | — |
 | | 🇦🇷 Argentina | CUIT/CUIL ✓ | — | — |
 | | 🇨🇱 Chile | RUT ✓ | — | — |
 | | 🇨🇴 Colombia | NIT ✓ | — | — |
+| **Middle East** | 🇧🇭 Bahrain | — | IBAN ✓ | — |
+| | 🇮🇱 Israel | — | IBAN ✓ | — |
+| | 🇯🇴 Jordan | — | IBAN ✓ | — |
+| | 🇰🇼 Kuwait | — | IBAN ✓ | — |
+| | 🇱🇧 Lebanon | — | IBAN ✓ | — |
+| | 🇶🇦 Qatar | — | IBAN ✓ | — |
+| | 🇸🇦 Saudi Arabia | — | IBAN ✓ | — |
+| | 🇦🇪 UAE | — | IBAN ✓ | — |
+| **Africa** | 🇪🇬 Egypt | — | IBAN ✓ | — |
+| | 🇲🇷 Mauritania | — | IBAN ✓ | — |
 | **Asia** | 🇨🇳 China | USCC ✓ | — | — |
 | | 🇯🇵 Japan | Corporate Number ✓ | — | — |
 | | 🇮🇳 India | GSTIN/PAN ✓ | — | — |
 | | 🇸🇬 Singapore | UEN ✓ | — | — |
+| | 🇰🇿 Kazakhstan | — | IBAN ✓ | — |
+| | 🇵🇰 Pakistan | — | IBAN ✓ | — |
+| | 🇹🇱 Timor-Leste | — | IBAN ✓ | — |
 | **Southeast Asia** | 🇮🇩 Indonesia | NPWP ✓ | — | — |
 | | 🇲🇾 Malaysia | TIN ✓ | — | — |
 | | 🇹🇭 Thailand | TIN ✓ | — | — |
@@ -147,8 +165,16 @@ dotnet add package Finova.Extensions.FluentValidation
 using Finova.Core.Iban;
 using Finova.Core.PaymentCard;
 using Finova.Core.Identifiers;
+using Finova.Services;
 
-// IBAN Validation
+// Global IBAN Validation (supports all IBAN-enabled countries worldwide)
+var result = GlobalIbanValidator.ValidateIban("BR1800360305000010009795493C1");
+if (result.IsValid)
+{
+    Console.WriteLine("Valid Brazilian IBAN!");
+}
+
+// Country-specific IBAN Validation
 var ibanService = new IbanService();
 var result = ibanService.Validate("BE68 5390 0754 7034");
 

--- a/examples/Finova.Examples.Console/Scenarios/GlobalServicesScenario.cs
+++ b/examples/Finova.Examples.Console/Scenarios/GlobalServicesScenario.cs
@@ -21,6 +21,7 @@ public static class GlobalServicesScenario
         RunGlobalTaxIdService(serviceProvider);
         RunGlobalBankAccountService(serviceProvider);
         RunEuropeIbanValidator(serviceProvider);
+        RunGlobalIbanValidator();
         RunGlobalAdaptersForEurope(serviceProvider);
         RunRegionalBankValidators(serviceProvider);
         RunGlobalBankValidatorFacade();
@@ -87,6 +88,147 @@ public static class GlobalServicesScenario
         {
             Console.WriteLine("EuropeIbanValidator not found in DI.");
         }
+    }
+
+    private static void RunGlobalIbanValidator()
+    {
+        ConsoleHelper.WriteSubHeader("26b", "Global IBAN Validator (Static - All Regions)");
+        ConsoleHelper.WriteCode("GlobalIbanValidator.ValidateIban(iban)");
+
+        Console.ForegroundColor = ConsoleColor.DarkCyan;
+        Console.WriteLine("      Validating IBANs from all supported regions:");
+        Console.ResetColor();
+        Console.WriteLine();
+
+        // Middle East IBANs
+        Console.ForegroundColor = ConsoleColor.Yellow;
+        Console.WriteLine("      === MIDDLE EAST ===");
+        Console.ResetColor();
+
+        var middleEastIbans = new[]
+        {
+            new { Iban = "AE070331234567890123456", Country = "United Arab Emirates", Valid = true },
+            new { Iban = "BH67BMAG00001299123456", Country = "Bahrain", Valid = true },
+            new { Iban = "IL620108000000099999999", Country = "Israel", Valid = true },
+            new { Iban = "JO94CBJO0010000000000131000302", Country = "Jordan", Valid = true },
+            new { Iban = "KW81CBKU0000000000001234560101", Country = "Kuwait", Valid = true },
+            new { Iban = "LB62099900000001001901229114", Country = "Lebanon", Valid = true },
+            new { Iban = "QA58DOHB00001234567890ABCDEFG", Country = "Qatar", Valid = true },
+            new { Iban = "SA0380000000608010167519", Country = "Saudi Arabia", Valid = true }
+        };
+
+        foreach (var test in middleEastIbans)
+        {
+            var result = GlobalIbanValidator.ValidateIban(test.Iban);
+            ConsoleHelper.WriteSimpleResult($"{test.Country}: {test.Iban}", result.IsValid,
+                result.IsValid ? "Valid" : (result.Errors.FirstOrDefault()?.Message ?? "Invalid"));
+        }
+        Console.WriteLine();
+
+        // Africa IBANs
+        Console.ForegroundColor = ConsoleColor.Yellow;
+        Console.WriteLine("      === AFRICA ===");
+        Console.ResetColor();
+
+        var africaIbans = new[]
+        {
+            new { Iban = "EG380019000500000000263180002", Country = "Egypt", Valid = true },
+            new { Iban = "MR1300020001010000123456753", Country = "Mauritania", Valid = true },
+            new { Iban = "TN5910006035183598478831", Country = "Tunisia (Europe validator)", Valid = true }
+        };
+
+        foreach (var test in africaIbans)
+        {
+            var result = GlobalIbanValidator.ValidateIban(test.Iban);
+            ConsoleHelper.WriteSimpleResult($"{test.Country}: {test.Iban}", result.IsValid,
+                result.IsValid ? "Valid" : (result.Errors.FirstOrDefault()?.Message ?? "Invalid"));
+        }
+        Console.WriteLine();
+
+        // Americas IBANs
+        Console.ForegroundColor = ConsoleColor.Yellow;
+        Console.WriteLine("      === AMERICAS ===");
+        Console.ResetColor();
+
+        var americasIbans = new[]
+        {
+            new { Iban = "BR1500000000000010932840814P2", Country = "Brazil", Valid = true },
+            new { Iban = "CR05015202001026284066", Country = "Costa Rica", Valid = true },
+            new { Iban = "DO28BAGR00000001212453611324", Country = "Dominican Republic", Valid = true },
+            new { Iban = "SV62CENR00000000000000700025", Country = "El Salvador", Valid = true },
+            new { Iban = "GT82TRAJ01020000001210029690", Country = "Guatemala", Valid = true },
+            new { Iban = "VG96VPVG0000012345678901", Country = "Virgin Islands (British)", Valid = true }
+        };
+
+        foreach (var test in americasIbans)
+        {
+            var result = GlobalIbanValidator.ValidateIban(test.Iban);
+            ConsoleHelper.WriteSimpleResult($"{test.Country}: {test.Iban}", result.IsValid,
+                result.IsValid ? "Valid" : (result.Errors.FirstOrDefault()?.Message ?? "Invalid"));
+        }
+        Console.WriteLine();
+
+        // Asia & Pacific IBANs
+        Console.ForegroundColor = ConsoleColor.Yellow;
+        Console.WriteLine("      === ASIA & PACIFIC ===");
+        Console.ResetColor();
+
+        var asiaIbans = new[]
+        {
+            new { Iban = "KZ86125KZT5004100100", Country = "Kazakhstan", Valid = true },
+            new { Iban = "PK36SCBL0000001123456702", Country = "Pakistan", Valid = true },
+            new { Iban = "TL380080012345678910157", Country = "Timor-Leste", Valid = true }
+        };
+
+        foreach (var test in asiaIbans)
+        {
+            var result = GlobalIbanValidator.ValidateIban(test.Iban);
+            ConsoleHelper.WriteSimpleResult($"{test.Country}: {test.Iban}", result.IsValid,
+                result.IsValid ? "Valid" : (result.Errors.FirstOrDefault()?.Message ?? "Invalid"));
+        }
+        Console.WriteLine();
+
+        // European IBANs (via GlobalIbanValidator routing)
+        Console.ForegroundColor = ConsoleColor.Yellow;
+        Console.WriteLine("      === EUROPE (via GlobalIbanValidator) ===");
+        Console.ResetColor();
+
+        var europeIbans = new[]
+        {
+            new { Iban = "DE89370400440532013000", Country = "Germany", Valid = true },
+            new { Iban = "FR7630006000011234567890189", Country = "France", Valid = true },
+            new { Iban = "GB29NWBK60161331926819", Country = "United Kingdom", Valid = true },
+            new { Iban = "NL91ABNA0417164300", Country = "Netherlands", Valid = true }
+        };
+
+        foreach (var test in europeIbans)
+        {
+            var result = GlobalIbanValidator.ValidateIban(test.Iban);
+            ConsoleHelper.WriteSimpleResult($"{test.Country}: {test.Iban}", result.IsValid,
+                result.IsValid ? "Valid" : (result.Errors.FirstOrDefault()?.Message ?? "Invalid"));
+        }
+        Console.WriteLine();
+
+        // Invalid IBANs
+        Console.ForegroundColor = ConsoleColor.Yellow;
+        Console.WriteLine("      === INVALID IBANS (Various Errors) ===");
+        Console.ResetColor();
+
+        var invalidIbans = new[]
+        {
+            new { Iban = "XX123456789012345", Country = "Unknown Country Code", Error = "Unsupported country" },
+            new { Iban = "DE89370400440532013001", Country = "Germany (Wrong Checksum)", Error = "Checksum error" },
+            new { Iban = "BH67BMAG000012991234", Country = "Bahrain (Too Short)", Error = "Length error" },
+            new { Iban = "", Country = "Empty Input", Error = "Empty input" }
+        };
+
+        foreach (var test in invalidIbans)
+        {
+            var result = GlobalIbanValidator.ValidateIban(test.Iban);
+            ConsoleHelper.WriteSimpleResult($"{test.Country}: {(string.IsNullOrEmpty(test.Iban) ? "(empty)" : test.Iban)}", result.IsValid,
+                result.IsValid ? "Valid" : (result.Errors.FirstOrDefault()?.Message ?? test.Error));
+        }
+        Console.WriteLine();
     }
 
     private static void RunGlobalAdaptersForEurope(ServiceProvider provider)

--- a/src/Finova.Core/Common/ValidationMessages.cs
+++ b/src/Finova.Core/Common/ValidationMessages.cs
@@ -18,6 +18,7 @@ public static class ValidationMessages
     public static string InvalidLength => GetString("InvalidLength");
     public static string InvalidCountryCode => GetString("InvalidCountryCode");
     public static string UnsupportedCountry => GetString("UnsupportedCountry");
+    public static string UnsupportedCountryOrInvalidIban => GetString("UnsupportedCountryOrInvalidIban");
     public static string UnsupportedFormat => GetString("UnsupportedFormat");
     public static string InvalidCheckDigit => GetString("InvalidCheckDigit");
     public static string MustContainOnlyDigits => GetString("MustContainOnlyDigits");

--- a/src/Finova.Core/Resources/ValidationMessages.de.resx
+++ b/src/Finova.Core/Resources/ValidationMessages.de.resx
@@ -79,6 +79,9 @@
   <data name="UnsupportedCountry" xml:space="preserve">
     <value>Land nicht unterstützt.</value>
   </data>
+  <data name="UnsupportedCountryOrInvalidIban" xml:space="preserve">
+    <value>Land nicht unterstützt oder IBAN ist ungültig.</value>
+  </data>
   <data name="InvalidCheckDigit" xml:space="preserve">
     <value>Ungültige Prüfziffern.</value>
   </data>

--- a/src/Finova.Core/Resources/ValidationMessages.fr.resx
+++ b/src/Finova.Core/Resources/ValidationMessages.fr.resx
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
@@ -77,6 +78,9 @@
   </data>
   <data name="UnsupportedCountry" xml:space="preserve">
     <value>Pays non pris en charge.</value>
+  </data>
+  <data name="UnsupportedCountryOrInvalidIban" xml:space="preserve">
+    <value>Pays non pris en charge ou IBAN invalide.</value>
   </data>
   <data name="InvalidCheckDigit" xml:space="preserve">
     <value>Chiffres de contrôle invalides.</value>
@@ -1227,11 +1231,12 @@
   <data name="VatTooShortForCountryCode" xml:space="preserve">
     <value>Le numéro de TVA est trop court pour extraire le code pays.</value>
   </data>
+  <!-- Securities Identifiers -->
   <data name="InvalidIsinLength" xml:space="preserve">
     <value>L'ISIN doit contenir exactement 12 caractères.</value>
   </data>
   <data name="InvalidIsinFormat" xml:space="preserve">
-    <value>L'ISIN doit commencer par 2 lettres suivies de 9 caractères alphanumériques et 1 chiffre de contrôle.</value>
+    <value>L'ISIN doit commencer par 2 lettres, suivies de 9 caractères alphanumériques et 1 chiffre de contrôle.</value>
   </data>
   <data name="InvalidIsinChecksum" xml:space="preserve">
     <value>Somme de contrôle ISIN invalide.</value>
@@ -1240,7 +1245,7 @@
     <value>Le CUSIP doit contenir exactement 9 caractères.</value>
   </data>
   <data name="InvalidCusipFormat" xml:space="preserve">
-    <value>Le CUSIP doit contenir 8 caractères alphanumériques suivis de 1 chiffre de contrôle.</value>
+    <value>Le CUSIP doit contenir 8 caractères alphanumériques suivis d'1 chiffre de contrôle.</value>
   </data>
   <data name="InvalidCusipChecksum" xml:space="preserve">
     <value>Somme de contrôle CUSIP invalide.</value>

--- a/src/Finova.Core/Resources/ValidationMessages.nl.resx
+++ b/src/Finova.Core/Resources/ValidationMessages.nl.resx
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
@@ -77,6 +78,9 @@
   </data>
   <data name="UnsupportedCountry" xml:space="preserve">
     <value>Land niet ondersteund.</value>
+  </data>
+  <data name="UnsupportedCountryOrInvalidIban" xml:space="preserve">
+    <value>Land niet ondersteund of IBAN is ongeldig.</value>
   </data>
   <data name="InvalidCheckDigit" xml:space="preserve">
     <value>Ongeldige controlecijfers.</value>
@@ -1227,26 +1231,27 @@
   <data name="InvalidSwedishOcrLength" xml:space="preserve">
     <value>Zweedse OCR-referentie moet tussen 2 en 25 cijfers zijn.</value>
   </data>
+  <!-- Securities Identifiers -->
   <data name="InvalidIsinLength" xml:space="preserve">
-    <value>ISIN moet exact 12 tekens bevatten.</value>
+    <value>ISIN moet precies 12 tekens bevatten.</value>
   </data>
   <data name="InvalidIsinFormat" xml:space="preserve">
-    <value>ISIN moet beginnen met 2 letters gevolgd door 9 alfanumerieke tekens en 1 controlecijfer.</value>
+    <value>ISIN moet beginnen met 2 letters, gevolgd door 9 alfanumerieke tekens en 1 controlecijfer.</value>
   </data>
   <data name="InvalidIsinChecksum" xml:space="preserve">
     <value>Ongeldige ISIN-controlesom.</value>
   </data>
   <data name="InvalidCusipLength" xml:space="preserve">
-    <value>CUSIP moet exact 9 tekens bevatten.</value>
+    <value>CUSIP moet precies 9 tekens bevatten.</value>
   </data>
   <data name="InvalidCusipFormat" xml:space="preserve">
-    <value>CUSIP moet 8 alfanumerieke tekens gevolgd door 1 controlecijfer bevatten.</value>
+    <value>CUSIP moet 8 alfanumerieke tekens bevatten gevolgd door 1 controlecijfer.</value>
   </data>
   <data name="InvalidCusipChecksum" xml:space="preserve">
     <value>Ongeldige CUSIP-controlesom.</value>
   </data>
   <data name="InvalidSedolLength" xml:space="preserve">
-    <value>SEDOL moet exact 7 tekens bevatten.</value>
+    <value>SEDOL moet precies 7 tekens bevatten.</value>
   </data>
   <data name="InvalidSedolFormat" xml:space="preserve">
     <value>SEDOL bevat ongeldige tekens. Klinkers (A, E, I, O, U) zijn niet toegestaan.</value>
@@ -1255,7 +1260,7 @@
     <value>Ongeldige SEDOL-controlesom.</value>
   </data>
   <data name="InvalidCurrencyLength" xml:space="preserve">
-    <value>Valutacode moet exact 3 tekens bevatten.</value>
+    <value>Valutacode moet precies 3 tekens bevatten.</value>
   </data>
   <data name="InvalidCurrencyCode" xml:space="preserve">
     <value>Onbekende valutacode.</value>

--- a/src/Finova.Core/Resources/ValidationMessages.resx
+++ b/src/Finova.Core/Resources/ValidationMessages.resx
@@ -79,6 +79,9 @@
   <data name="UnsupportedCountry" xml:space="preserve">
     <value>Country not supported.</value>
   </data>
+  <data name="UnsupportedCountryOrInvalidIban" xml:space="preserve">
+    <value>Country not supported or IBAN is invalid.</value>
+  </data>
   <data name="InvalidCheckDigit" xml:space="preserve">
     <value>Invalid check digits.</value>
   </data>
@@ -1228,11 +1231,12 @@
   <data name="InvalidSwedishOcrLength" xml:space="preserve">
     <value>Swedish OCR reference must be between 2 and 25 digits.</value>
   </data>
+  <!-- Securities Identifiers -->
   <data name="InvalidIsinLength" xml:space="preserve">
     <value>ISIN must be exactly 12 characters.</value>
   </data>
   <data name="InvalidIsinFormat" xml:space="preserve">
-    <value>ISIN must start with 2 letters followed by 9 alphanumeric characters and 1 check digit.</value>
+    <value>ISIN must start with 2 letters, followed by 9 alphanumeric characters and 1 check digit.</value>
   </data>
   <data name="InvalidIsinChecksum" xml:space="preserve">
     <value>Invalid ISIN checksum.</value>

--- a/src/Finova/Countries/Africa/Egypt/Validators/EgyptIbanValidator.cs
+++ b/src/Finova/Countries/Africa/Egypt/Validators/EgyptIbanValidator.cs
@@ -1,0 +1,53 @@
+using System.Diagnostics.CodeAnalysis;
+using Finova.Core.Common;
+using Finova.Core.Iban;
+
+namespace Finova.Countries.Africa.Egypt.Validators;
+
+/// <summary>
+/// Validator for Egypt IBANs.
+/// Egypt IBAN format: EG + 2 check digits + 4 digits (bank code) + 4 digits (branch) + 17 digits (account)
+/// Length: 29 characters
+/// Example: EG380019000500000000263180002
+/// </summary>
+public class EgyptIbanValidator : IIbanValidator
+{
+    public string CountryCode => "EG";
+
+    private const int EgyptIbanLength = 29;
+    private const string EgyptCountryCode = "EG";
+
+    public ValidationResult Validate(string? iban) => ValidateEgyptIban(iban);
+
+    public static ValidationResult ValidateEgyptIban([NotNullWhen(true)] string? iban)
+    {
+        if (string.IsNullOrWhiteSpace(iban))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidInput, ValidationMessages.InputCannotBeEmpty);
+        }
+
+        var normalized = IbanHelper.NormalizeIban(iban);
+
+        if (normalized.Length != EgyptIbanLength)
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidLength,
+                string.Format(ValidationMessages.InvalidLengthExpectedXGotY, EgyptIbanLength, normalized.Length));
+        }
+
+        if (!normalized.StartsWith(EgyptCountryCode, StringComparison.OrdinalIgnoreCase))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidCountryCode, ValidationMessages.InvalidCountryCode);
+        }
+
+        // BBAN (25 digits: 4 bank + 4 branch + 17 account)
+        string bban = normalized.Substring(4);
+        if (!bban.All(char.IsDigit))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidFormat, ValidationMessages.MustContainOnlyDigits);
+        }
+
+        return IbanHelper.IsValidIban(normalized)
+            ? ValidationResult.Success()
+            : ValidationResult.Failure(ValidationErrorCode.InvalidChecksum, ValidationMessages.InvalidChecksum);
+    }
+}

--- a/src/Finova/Countries/Africa/Mauritania/Validators/MauritaniaIbanValidator.cs
+++ b/src/Finova/Countries/Africa/Mauritania/Validators/MauritaniaIbanValidator.cs
@@ -1,0 +1,53 @@
+using System.Diagnostics.CodeAnalysis;
+using Finova.Core.Common;
+using Finova.Core.Iban;
+
+namespace Finova.Countries.Africa.Mauritania.Validators;
+
+/// <summary>
+/// Validator for Mauritania IBANs.
+/// Mauritania IBAN format: MR + 2 check digits + 5 digits (bank code) + 5 digits (branch) + 11 digits (account) + 2 digits (key)
+/// Length: 27 characters
+/// Example: MR1300020001010000123456753
+/// </summary>
+public class MauritaniaIbanValidator : IIbanValidator
+{
+    public string CountryCode => "MR";
+
+    private const int MauritaniaIbanLength = 27;
+    private const string MauritaniaCountryCode = "MR";
+
+    public ValidationResult Validate(string? iban) => ValidateMauritaniaIban(iban);
+
+    public static ValidationResult ValidateMauritaniaIban([NotNullWhen(true)] string? iban)
+    {
+        if (string.IsNullOrWhiteSpace(iban))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidInput, ValidationMessages.InputCannotBeEmpty);
+        }
+
+        var normalized = IbanHelper.NormalizeIban(iban);
+
+        if (normalized.Length != MauritaniaIbanLength)
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidLength,
+                string.Format(ValidationMessages.InvalidLengthExpectedXGotY, MauritaniaIbanLength, normalized.Length));
+        }
+
+        if (!normalized.StartsWith(MauritaniaCountryCode, StringComparison.OrdinalIgnoreCase))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidCountryCode, ValidationMessages.InvalidCountryCode);
+        }
+
+        // BBAN (23 digits)
+        string bban = normalized.Substring(4);
+        if (!bban.All(char.IsDigit))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidFormat, ValidationMessages.MustContainOnlyDigits);
+        }
+
+        return IbanHelper.IsValidIban(normalized)
+            ? ValidationResult.Success()
+            : ValidationResult.Failure(ValidationErrorCode.InvalidChecksum, ValidationMessages.InvalidChecksum);
+    }
+}

--- a/src/Finova/Countries/Asia/Kazakhstan/Validators/KazakhstanIbanValidator.cs
+++ b/src/Finova/Countries/Asia/Kazakhstan/Validators/KazakhstanIbanValidator.cs
@@ -1,0 +1,61 @@
+using System.Diagnostics.CodeAnalysis;
+using Finova.Core.Common;
+using Finova.Core.Iban;
+
+namespace Finova.Countries.Asia.Kazakhstan.Validators;
+
+/// <summary>
+/// Validator for Kazakhstan IBANs.
+/// Kazakhstan IBAN format: KZ + 2 check digits + 3 digits (bank code) + 13 alphanumeric (account)
+/// Length: 20 characters
+/// Example: KZ86125KZT5004100100
+/// </summary>
+public class KazakhstanIbanValidator : IIbanValidator
+{
+    public string CountryCode => "KZ";
+
+    private const int KazakhstanIbanLength = 20;
+    private const string KazakhstanCountryCode = "KZ";
+
+    public ValidationResult Validate(string? iban) => ValidateKazakhstanIban(iban);
+
+    public static ValidationResult ValidateKazakhstanIban([NotNullWhen(true)] string? iban)
+    {
+        if (string.IsNullOrWhiteSpace(iban))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidInput, ValidationMessages.InputCannotBeEmpty);
+        }
+
+        var normalized = IbanHelper.NormalizeIban(iban);
+
+        if (normalized.Length != KazakhstanIbanLength)
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidLength,
+                string.Format(ValidationMessages.InvalidLengthExpectedXGotY, KazakhstanIbanLength, normalized.Length));
+        }
+
+        if (!normalized.StartsWith(KazakhstanCountryCode, StringComparison.OrdinalIgnoreCase))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidCountryCode, ValidationMessages.InvalidCountryCode);
+        }
+
+        // Validate BBAN format: 3 digits (bank code) + 13 alphanumeric (account)
+        string bban = normalized.Substring(4);
+
+        // Bank code (3 digits)
+        if (!bban.Substring(0, 3).All(char.IsDigit))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidFormat, ValidationMessages.InvalidFormat);
+        }
+
+        // Account number (13 alphanumeric)
+        if (!bban.Substring(3).All(char.IsLetterOrDigit))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidFormat, ValidationMessages.InvalidFormat);
+        }
+
+        return IbanHelper.IsValidIban(normalized)
+            ? ValidationResult.Success()
+            : ValidationResult.Failure(ValidationErrorCode.InvalidChecksum, ValidationMessages.InvalidChecksum);
+    }
+}

--- a/src/Finova/Countries/Asia/Pakistan/Validators/PakistanIbanValidator.cs
+++ b/src/Finova/Countries/Asia/Pakistan/Validators/PakistanIbanValidator.cs
@@ -1,0 +1,61 @@
+using System.Diagnostics.CodeAnalysis;
+using Finova.Core.Common;
+using Finova.Core.Iban;
+
+namespace Finova.Countries.Asia.Pakistan.Validators;
+
+/// <summary>
+/// Validator for Pakistan IBANs.
+/// Pakistan IBAN format: PK + 2 check digits + 4 letters (bank code) + 16 digits (account)
+/// Length: 24 characters
+/// Example: PK36SCBL0000001123456702
+/// </summary>
+public class PakistanIbanValidator : IIbanValidator
+{
+    public string CountryCode => "PK";
+
+    private const int PakistanIbanLength = 24;
+    private const string PakistanCountryCode = "PK";
+
+    public ValidationResult Validate(string? iban) => ValidatePakistanIban(iban);
+
+    public static ValidationResult ValidatePakistanIban([NotNullWhen(true)] string? iban)
+    {
+        if (string.IsNullOrWhiteSpace(iban))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidInput, ValidationMessages.InputCannotBeEmpty);
+        }
+
+        var normalized = IbanHelper.NormalizeIban(iban);
+
+        if (normalized.Length != PakistanIbanLength)
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidLength,
+                string.Format(ValidationMessages.InvalidLengthExpectedXGotY, PakistanIbanLength, normalized.Length));
+        }
+
+        if (!normalized.StartsWith(PakistanCountryCode, StringComparison.OrdinalIgnoreCase))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidCountryCode, ValidationMessages.InvalidCountryCode);
+        }
+
+        // Validate BBAN format: 4 letters (bank code) + 16 digits (account)
+        string bban = normalized.Substring(4);
+
+        // Bank code (4 letters)
+        if (!bban.Substring(0, 4).All(char.IsLetter))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidFormat, ValidationMessages.InvalidFormat);
+        }
+
+        // Account number (16 digits)
+        if (!bban.Substring(4).All(char.IsDigit))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidFormat, ValidationMessages.InvalidFormat);
+        }
+
+        return IbanHelper.IsValidIban(normalized)
+            ? ValidationResult.Success()
+            : ValidationResult.Failure(ValidationErrorCode.InvalidChecksum, ValidationMessages.InvalidChecksum);
+    }
+}

--- a/src/Finova/Countries/Asia/TimorLeste/Validators/TimorLesteIbanValidator.cs
+++ b/src/Finova/Countries/Asia/TimorLeste/Validators/TimorLesteIbanValidator.cs
@@ -1,0 +1,53 @@
+using System.Diagnostics.CodeAnalysis;
+using Finova.Core.Common;
+using Finova.Core.Iban;
+
+namespace Finova.Countries.Asia.TimorLeste.Validators;
+
+/// <summary>
+/// Validator for Timor-Leste (East Timor) IBANs.
+/// Timor-Leste IBAN format: TL + 2 check digits + 3 digits (bank code) + 14 digits (account) + 2 digits (check)
+/// Length: 23 characters
+/// Example: TL380080012345678910157
+/// </summary>
+public class TimorLesteIbanValidator : IIbanValidator
+{
+    public string CountryCode => "TL";
+
+    private const int TimorLesteIbanLength = 23;
+    private const string TimorLesteCountryCode = "TL";
+
+    public ValidationResult Validate(string? iban) => ValidateTimorLesteIban(iban);
+
+    public static ValidationResult ValidateTimorLesteIban([NotNullWhen(true)] string? iban)
+    {
+        if (string.IsNullOrWhiteSpace(iban))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidInput, ValidationMessages.InputCannotBeEmpty);
+        }
+
+        var normalized = IbanHelper.NormalizeIban(iban);
+
+        if (normalized.Length != TimorLesteIbanLength)
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidLength,
+                string.Format(ValidationMessages.InvalidLengthExpectedXGotY, TimorLesteIbanLength, normalized.Length));
+        }
+
+        if (!normalized.StartsWith(TimorLesteCountryCode, StringComparison.OrdinalIgnoreCase))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidCountryCode, ValidationMessages.InvalidCountryCode);
+        }
+
+        // BBAN (19 digits: 3 bank + 14 account + 2 check)
+        string bban = normalized.Substring(4);
+        if (!bban.All(char.IsDigit))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidFormat, ValidationMessages.MustContainOnlyDigits);
+        }
+
+        return IbanHelper.IsValidIban(normalized)
+            ? ValidationResult.Success()
+            : ValidationResult.Failure(ValidationErrorCode.InvalidChecksum, ValidationMessages.InvalidChecksum);
+    }
+}

--- a/src/Finova/Countries/MiddleEast/Bahrain/Validators/BahrainIbanValidator.cs
+++ b/src/Finova/Countries/MiddleEast/Bahrain/Validators/BahrainIbanValidator.cs
@@ -1,0 +1,58 @@
+using System.Diagnostics.CodeAnalysis;
+using Finova.Core.Common;
+using Finova.Core.Iban;
+
+namespace Finova.Countries.MiddleEast.Bahrain.Validators;
+
+/// <summary>
+/// Validator for Bahrain IBANs.
+/// Bahrain IBAN format: BH + 2 check digits + 4 letters (bank code) + 14 alphanumeric (account)
+/// Length: 22 characters
+/// Example: BH67BMAG00001299123456
+/// </summary>
+public class BahrainIbanValidator : IIbanValidator
+{
+    public string CountryCode => "BH";
+
+    private const int BahrainIbanLength = 22;
+    private const string BahrainCountryCode = "BH";
+
+    public ValidationResult Validate(string? iban) => ValidateBahrainIban(iban);
+
+    public static ValidationResult ValidateBahrainIban([NotNullWhen(true)] string? iban)
+    {
+        if (string.IsNullOrWhiteSpace(iban))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidInput, ValidationMessages.InputCannotBeEmpty);
+        }
+
+        var normalized = IbanHelper.NormalizeIban(iban);
+
+        if (normalized.Length != BahrainIbanLength)
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidLength,
+                string.Format(ValidationMessages.InvalidLengthExpectedXGotY, BahrainIbanLength, normalized.Length));
+        }
+
+        if (!normalized.StartsWith(BahrainCountryCode, StringComparison.OrdinalIgnoreCase))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidCountryCode, ValidationMessages.InvalidCountryCode);
+        }
+
+        // Validate BBAN format: 4 letters (bank code) + 14 alphanumeric (account)
+        string bban = normalized.Substring(4);
+        if (!bban.Substring(0, 4).All(char.IsLetter))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidFormat, ValidationMessages.InvalidFormat);
+        }
+
+        if (!bban.Substring(4).All(char.IsLetterOrDigit))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidFormat, ValidationMessages.InvalidFormat);
+        }
+
+        return IbanHelper.IsValidIban(normalized)
+            ? ValidationResult.Success()
+            : ValidationResult.Failure(ValidationErrorCode.InvalidChecksum, ValidationMessages.InvalidChecksum);
+    }
+}

--- a/src/Finova/Countries/MiddleEast/Israel/Validators/IsraelIbanValidator.cs
+++ b/src/Finova/Countries/MiddleEast/Israel/Validators/IsraelIbanValidator.cs
@@ -1,0 +1,53 @@
+using System.Diagnostics.CodeAnalysis;
+using Finova.Core.Common;
+using Finova.Core.Iban;
+
+namespace Finova.Countries.MiddleEast.Israel.Validators;
+
+/// <summary>
+/// Validator for Israel IBANs.
+/// Israel IBAN format: IL + 2 check digits + 3 digits (bank code) + 3 digits (branch code) + 13 digits (account)
+/// Length: 23 characters
+/// Example: IL620108000000099999999
+/// </summary>
+public class IsraelIbanValidator : IIbanValidator
+{
+    public string CountryCode => "IL";
+
+    private const int IsraelIbanLength = 23;
+    private const string IsraelCountryCode = "IL";
+
+    public ValidationResult Validate(string? iban) => ValidateIsraelIban(iban);
+
+    public static ValidationResult ValidateIsraelIban([NotNullWhen(true)] string? iban)
+    {
+        if (string.IsNullOrWhiteSpace(iban))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidInput, ValidationMessages.InputCannotBeEmpty);
+        }
+
+        var normalized = IbanHelper.NormalizeIban(iban);
+
+        if (normalized.Length != IsraelIbanLength)
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidLength,
+                string.Format(ValidationMessages.InvalidLengthExpectedXGotY, IsraelIbanLength, normalized.Length));
+        }
+
+        if (!normalized.StartsWith(IsraelCountryCode, StringComparison.OrdinalIgnoreCase))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidCountryCode, ValidationMessages.InvalidCountryCode);
+        }
+
+        // BBAN (19 digits)
+        string bban = normalized.Substring(4);
+        if (!bban.All(char.IsDigit))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidFormat, ValidationMessages.MustContainOnlyDigits);
+        }
+
+        return IbanHelper.IsValidIban(normalized)
+            ? ValidationResult.Success()
+            : ValidationResult.Failure(ValidationErrorCode.InvalidChecksum, ValidationMessages.InvalidChecksum);
+    }
+}

--- a/src/Finova/Countries/MiddleEast/Jordan/Validators/JordanIbanValidator.cs
+++ b/src/Finova/Countries/MiddleEast/Jordan/Validators/JordanIbanValidator.cs
@@ -1,0 +1,67 @@
+using System.Diagnostics.CodeAnalysis;
+using Finova.Core.Common;
+using Finova.Core.Iban;
+
+namespace Finova.Countries.MiddleEast.Jordan.Validators;
+
+/// <summary>
+/// Validator for Jordan IBANs.
+/// Jordan IBAN format: JO + 2 check digits + 4 letters (bank code) + 4 digits (branch) + 18 alphanumeric (account)
+/// Length: 30 characters
+/// Example: JO94CBJO0010000000000131000302
+/// </summary>
+public class JordanIbanValidator : IIbanValidator
+{
+    public string CountryCode => "JO";
+
+    private const int JordanIbanLength = 30;
+    private const string JordanCountryCode = "JO";
+
+    public ValidationResult Validate(string? iban) => ValidateJordanIban(iban);
+
+    public static ValidationResult ValidateJordanIban([NotNullWhen(true)] string? iban)
+    {
+        if (string.IsNullOrWhiteSpace(iban))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidInput, ValidationMessages.InputCannotBeEmpty);
+        }
+
+        var normalized = IbanHelper.NormalizeIban(iban);
+
+        if (normalized.Length != JordanIbanLength)
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidLength,
+                string.Format(ValidationMessages.InvalidLengthExpectedXGotY, JordanIbanLength, normalized.Length));
+        }
+
+        if (!normalized.StartsWith(JordanCountryCode, StringComparison.OrdinalIgnoreCase))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidCountryCode, ValidationMessages.InvalidCountryCode);
+        }
+
+        // Validate BBAN format: 4 letters (bank code) + 4 digits (branch) + 18 alphanumeric (account)
+        string bban = normalized.Substring(4);
+
+        // Bank code (4 letters)
+        if (!bban.Substring(0, 4).All(char.IsLetter))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidFormat, ValidationMessages.InvalidFormat);
+        }
+
+        // Branch code (4 digits)
+        if (!bban.Substring(4, 4).All(char.IsDigit))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidFormat, ValidationMessages.InvalidFormat);
+        }
+
+        // Account number (18 alphanumeric)
+        if (!bban.Substring(8).All(char.IsLetterOrDigit))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidFormat, ValidationMessages.InvalidFormat);
+        }
+
+        return IbanHelper.IsValidIban(normalized)
+            ? ValidationResult.Success()
+            : ValidationResult.Failure(ValidationErrorCode.InvalidChecksum, ValidationMessages.InvalidChecksum);
+    }
+}

--- a/src/Finova/Countries/MiddleEast/Kuwait/Validators/KuwaitIbanValidator.cs
+++ b/src/Finova/Countries/MiddleEast/Kuwait/Validators/KuwaitIbanValidator.cs
@@ -1,0 +1,61 @@
+using System.Diagnostics.CodeAnalysis;
+using Finova.Core.Common;
+using Finova.Core.Iban;
+
+namespace Finova.Countries.MiddleEast.Kuwait.Validators;
+
+/// <summary>
+/// Validator for Kuwait IBANs.
+/// Kuwait IBAN format: KW + 2 check digits + 4 letters (bank code) + 22 alphanumeric (account)
+/// Length: 30 characters
+/// Example: KW81CBKU0000000000001234560101
+/// </summary>
+public class KuwaitIbanValidator : IIbanValidator
+{
+    public string CountryCode => "KW";
+
+    private const int KuwaitIbanLength = 30;
+    private const string KuwaitCountryCode = "KW";
+
+    public ValidationResult Validate(string? iban) => ValidateKuwaitIban(iban);
+
+    public static ValidationResult ValidateKuwaitIban([NotNullWhen(true)] string? iban)
+    {
+        if (string.IsNullOrWhiteSpace(iban))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidInput, ValidationMessages.InputCannotBeEmpty);
+        }
+
+        var normalized = IbanHelper.NormalizeIban(iban);
+
+        if (normalized.Length != KuwaitIbanLength)
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidLength,
+                string.Format(ValidationMessages.InvalidLengthExpectedXGotY, KuwaitIbanLength, normalized.Length));
+        }
+
+        if (!normalized.StartsWith(KuwaitCountryCode, StringComparison.OrdinalIgnoreCase))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidCountryCode, ValidationMessages.InvalidCountryCode);
+        }
+
+        // Validate BBAN format: 4 letters (bank code) + 22 alphanumeric (account)
+        string bban = normalized.Substring(4);
+
+        // Bank code (4 letters)
+        if (!bban.Substring(0, 4).All(char.IsLetter))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidFormat, ValidationMessages.InvalidFormat);
+        }
+
+        // Account number (22 alphanumeric)
+        if (!bban.Substring(4).All(char.IsLetterOrDigit))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidFormat, ValidationMessages.InvalidFormat);
+        }
+
+        return IbanHelper.IsValidIban(normalized)
+            ? ValidationResult.Success()
+            : ValidationResult.Failure(ValidationErrorCode.InvalidChecksum, ValidationMessages.InvalidChecksum);
+    }
+}

--- a/src/Finova/Countries/MiddleEast/Lebanon/Validators/LebanonIbanValidator.cs
+++ b/src/Finova/Countries/MiddleEast/Lebanon/Validators/LebanonIbanValidator.cs
@@ -1,0 +1,61 @@
+using System.Diagnostics.CodeAnalysis;
+using Finova.Core.Common;
+using Finova.Core.Iban;
+
+namespace Finova.Countries.MiddleEast.Lebanon.Validators;
+
+/// <summary>
+/// Validator for Lebanon IBANs.
+/// Lebanon IBAN format: LB + 2 check digits + 4 digits (bank code) + 20 alphanumeric (account)
+/// Length: 28 characters
+/// Example: LB62099900000001001901229114
+/// </summary>
+public class LebanonIbanValidator : IIbanValidator
+{
+    public string CountryCode => "LB";
+
+    private const int LebanonIbanLength = 28;
+    private const string LebanonCountryCode = "LB";
+
+    public ValidationResult Validate(string? iban) => ValidateLebanonIban(iban);
+
+    public static ValidationResult ValidateLebanonIban([NotNullWhen(true)] string? iban)
+    {
+        if (string.IsNullOrWhiteSpace(iban))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidInput, ValidationMessages.InputCannotBeEmpty);
+        }
+
+        var normalized = IbanHelper.NormalizeIban(iban);
+
+        if (normalized.Length != LebanonIbanLength)
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidLength,
+                string.Format(ValidationMessages.InvalidLengthExpectedXGotY, LebanonIbanLength, normalized.Length));
+        }
+
+        if (!normalized.StartsWith(LebanonCountryCode, StringComparison.OrdinalIgnoreCase))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidCountryCode, ValidationMessages.InvalidCountryCode);
+        }
+
+        // Validate BBAN format: 4 digits (bank code) + 20 alphanumeric (account)
+        string bban = normalized.Substring(4);
+
+        // Bank code (4 digits)
+        if (!bban.Substring(0, 4).All(char.IsDigit))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidFormat, ValidationMessages.InvalidFormat);
+        }
+
+        // Account number (20 alphanumeric)
+        if (!bban.Substring(4).All(char.IsLetterOrDigit))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidFormat, ValidationMessages.InvalidFormat);
+        }
+
+        return IbanHelper.IsValidIban(normalized)
+            ? ValidationResult.Success()
+            : ValidationResult.Failure(ValidationErrorCode.InvalidChecksum, ValidationMessages.InvalidChecksum);
+    }
+}

--- a/src/Finova/Countries/MiddleEast/Qatar/Validators/QatarIbanValidator.cs
+++ b/src/Finova/Countries/MiddleEast/Qatar/Validators/QatarIbanValidator.cs
@@ -1,0 +1,61 @@
+using System.Diagnostics.CodeAnalysis;
+using Finova.Core.Common;
+using Finova.Core.Iban;
+
+namespace Finova.Countries.MiddleEast.Qatar.Validators;
+
+/// <summary>
+/// Validator for Qatar IBANs.
+/// Qatar IBAN format: QA + 2 check digits + 4 letters (bank code) + 21 alphanumeric (account)
+/// Length: 29 characters
+/// Example: QA58DOHB00001234567890ABCDEFG
+/// </summary>
+public class QatarIbanValidator : IIbanValidator
+{
+    public string CountryCode => "QA";
+
+    private const int QatarIbanLength = 29;
+    private const string QatarCountryCode = "QA";
+
+    public ValidationResult Validate(string? iban) => ValidateQatarIban(iban);
+
+    public static ValidationResult ValidateQatarIban([NotNullWhen(true)] string? iban)
+    {
+        if (string.IsNullOrWhiteSpace(iban))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidInput, ValidationMessages.InputCannotBeEmpty);
+        }
+
+        var normalized = IbanHelper.NormalizeIban(iban);
+
+        if (normalized.Length != QatarIbanLength)
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidLength,
+                string.Format(ValidationMessages.InvalidLengthExpectedXGotY, QatarIbanLength, normalized.Length));
+        }
+
+        if (!normalized.StartsWith(QatarCountryCode, StringComparison.OrdinalIgnoreCase))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidCountryCode, ValidationMessages.InvalidCountryCode);
+        }
+
+        // Validate BBAN format: 4 letters (bank code) + 21 alphanumeric (account)
+        string bban = normalized.Substring(4);
+
+        // Bank code (4 letters)
+        if (!bban.Substring(0, 4).All(char.IsLetter))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidFormat, ValidationMessages.InvalidFormat);
+        }
+
+        // Account number (21 alphanumeric)
+        if (!bban.Substring(4).All(char.IsLetterOrDigit))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidFormat, ValidationMessages.InvalidFormat);
+        }
+
+        return IbanHelper.IsValidIban(normalized)
+            ? ValidationResult.Success()
+            : ValidationResult.Failure(ValidationErrorCode.InvalidChecksum, ValidationMessages.InvalidChecksum);
+    }
+}

--- a/src/Finova/Countries/MiddleEast/SaudiArabia/Validators/SaudiArabiaIbanValidator.cs
+++ b/src/Finova/Countries/MiddleEast/SaudiArabia/Validators/SaudiArabiaIbanValidator.cs
@@ -1,0 +1,61 @@
+using System.Diagnostics.CodeAnalysis;
+using Finova.Core.Common;
+using Finova.Core.Iban;
+
+namespace Finova.Countries.MiddleEast.SaudiArabia.Validators;
+
+/// <summary>
+/// Validator for Saudi Arabia IBANs.
+/// Saudi Arabia IBAN format: SA + 2 check digits + 2 digits (bank code) + 18 alphanumeric (account)
+/// Length: 24 characters
+/// Example: SA0380000000608010167519
+/// </summary>
+public class SaudiArabiaIbanValidator : IIbanValidator
+{
+    public string CountryCode => "SA";
+
+    private const int SaudiArabiaIbanLength = 24;
+    private const string SaudiArabiaCountryCode = "SA";
+
+    public ValidationResult Validate(string? iban) => ValidateSaudiArabiaIban(iban);
+
+    public static ValidationResult ValidateSaudiArabiaIban([NotNullWhen(true)] string? iban)
+    {
+        if (string.IsNullOrWhiteSpace(iban))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidInput, ValidationMessages.InputCannotBeEmpty);
+        }
+
+        var normalized = IbanHelper.NormalizeIban(iban);
+
+        if (normalized.Length != SaudiArabiaIbanLength)
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidLength,
+                string.Format(ValidationMessages.InvalidLengthExpectedXGotY, SaudiArabiaIbanLength, normalized.Length));
+        }
+
+        if (!normalized.StartsWith(SaudiArabiaCountryCode, StringComparison.OrdinalIgnoreCase))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidCountryCode, ValidationMessages.InvalidCountryCode);
+        }
+
+        // Validate BBAN format: 2 digits (bank code) + 18 alphanumeric (account)
+        string bban = normalized.Substring(4);
+
+        // Bank code (2 digits)
+        if (!bban.Substring(0, 2).All(char.IsDigit))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidFormat, ValidationMessages.InvalidFormat);
+        }
+
+        // Account number (18 alphanumeric)
+        if (!bban.Substring(2).All(char.IsLetterOrDigit))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidFormat, ValidationMessages.InvalidFormat);
+        }
+
+        return IbanHelper.IsValidIban(normalized)
+            ? ValidationResult.Success()
+            : ValidationResult.Failure(ValidationErrorCode.InvalidChecksum, ValidationMessages.InvalidChecksum);
+    }
+}

--- a/src/Finova/Countries/MiddleEast/UAE/Validators/UAEIbanValidator.cs
+++ b/src/Finova/Countries/MiddleEast/UAE/Validators/UAEIbanValidator.cs
@@ -1,0 +1,53 @@
+using System.Diagnostics.CodeAnalysis;
+using Finova.Core.Common;
+using Finova.Core.Iban;
+
+namespace Finova.Countries.MiddleEast.UAE.Validators;
+
+/// <summary>
+/// Validator for United Arab Emirates IBANs.
+/// UAE IBAN format: AE + 2 check digits + 3 digits (bank code) + 16 digits (account)
+/// Length: 23 characters
+/// Example: AE070331234567890123456
+/// </summary>
+public class UAEIbanValidator : IIbanValidator
+{
+    public string CountryCode => "AE";
+
+    private const int UAEIbanLength = 23;
+    private const string UAECountryCode = "AE";
+
+    public ValidationResult Validate(string? iban) => ValidateUAEIban(iban);
+
+    public static ValidationResult ValidateUAEIban([NotNullWhen(true)] string? iban)
+    {
+        if (string.IsNullOrWhiteSpace(iban))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidInput, ValidationMessages.InputCannotBeEmpty);
+        }
+
+        var normalized = IbanHelper.NormalizeIban(iban);
+
+        if (normalized.Length != UAEIbanLength)
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidLength,
+                string.Format(ValidationMessages.InvalidLengthExpectedXGotY, UAEIbanLength, normalized.Length));
+        }
+
+        if (!normalized.StartsWith(UAECountryCode, StringComparison.OrdinalIgnoreCase))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidCountryCode, ValidationMessages.InvalidCountryCode);
+        }
+
+        // BBAN (19 digits: 3 bank code + 16 account)
+        string bban = normalized.Substring(4);
+        if (!bban.All(char.IsDigit))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidFormat, ValidationMessages.MustContainOnlyDigits);
+        }
+
+        return IbanHelper.IsValidIban(normalized)
+            ? ValidationResult.Success()
+            : ValidationResult.Failure(ValidationErrorCode.InvalidChecksum, ValidationMessages.InvalidChecksum);
+    }
+}

--- a/src/Finova/Countries/NorthAmerica/CostaRica/Validators/CostaRicaIbanValidator.cs
+++ b/src/Finova/Countries/NorthAmerica/CostaRica/Validators/CostaRicaIbanValidator.cs
@@ -1,0 +1,53 @@
+using System.Diagnostics.CodeAnalysis;
+using Finova.Core.Common;
+using Finova.Core.Iban;
+
+namespace Finova.Countries.NorthAmerica.CostaRica.Validators;
+
+/// <summary>
+/// Validator for Costa Rica IBANs.
+/// Costa Rica IBAN format: CR + 2 check digits + 1 digit (reserve) + 3 digits (bank code) + 14 digits (account)
+/// Length: 22 characters
+/// Example: CR05015202001026284066
+/// </summary>
+public class CostaRicaIbanValidator : IIbanValidator
+{
+    public string CountryCode => "CR";
+
+    private const int CostaRicaIbanLength = 22;
+    private const string CostaRicaCountryCode = "CR";
+
+    public ValidationResult Validate(string? iban) => ValidateCostaRicaIban(iban);
+
+    public static ValidationResult ValidateCostaRicaIban([NotNullWhen(true)] string? iban)
+    {
+        if (string.IsNullOrWhiteSpace(iban))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidInput, ValidationMessages.InputCannotBeEmpty);
+        }
+
+        var normalized = IbanHelper.NormalizeIban(iban);
+
+        if (normalized.Length != CostaRicaIbanLength)
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidLength,
+                string.Format(ValidationMessages.InvalidLengthExpectedXGotY, CostaRicaIbanLength, normalized.Length));
+        }
+
+        if (!normalized.StartsWith(CostaRicaCountryCode, StringComparison.OrdinalIgnoreCase))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidCountryCode, ValidationMessages.InvalidCountryCode);
+        }
+
+        // BBAN (18 digits: 1 reserve + 3 bank + 14 account)
+        string bban = normalized.Substring(4);
+        if (!bban.All(char.IsDigit))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidFormat, ValidationMessages.MustContainOnlyDigits);
+        }
+
+        return IbanHelper.IsValidIban(normalized)
+            ? ValidationResult.Success()
+            : ValidationResult.Failure(ValidationErrorCode.InvalidChecksum, ValidationMessages.InvalidChecksum);
+    }
+}

--- a/src/Finova/Countries/NorthAmerica/DominicanRepublic/Validators/DominicanRepublicIbanValidator.cs
+++ b/src/Finova/Countries/NorthAmerica/DominicanRepublic/Validators/DominicanRepublicIbanValidator.cs
@@ -1,0 +1,61 @@
+using System.Diagnostics.CodeAnalysis;
+using Finova.Core.Common;
+using Finova.Core.Iban;
+
+namespace Finova.Countries.NorthAmerica.DominicanRepublic.Validators;
+
+/// <summary>
+/// Validator for Dominican Republic IBANs.
+/// Dominican Republic IBAN format: DO + 2 check digits + 4 letters (bank code) + 20 digits (account)
+/// Length: 28 characters
+/// Example: DO28BAGR00000001212453611324
+/// </summary>
+public class DominicanRepublicIbanValidator : IIbanValidator
+{
+    public string CountryCode => "DO";
+
+    private const int DominicanRepublicIbanLength = 28;
+    private const string DominicanRepublicCountryCode = "DO";
+
+    public ValidationResult Validate(string? iban) => ValidateDominicanRepublicIban(iban);
+
+    public static ValidationResult ValidateDominicanRepublicIban([NotNullWhen(true)] string? iban)
+    {
+        if (string.IsNullOrWhiteSpace(iban))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidInput, ValidationMessages.InputCannotBeEmpty);
+        }
+
+        var normalized = IbanHelper.NormalizeIban(iban);
+
+        if (normalized.Length != DominicanRepublicIbanLength)
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidLength,
+                string.Format(ValidationMessages.InvalidLengthExpectedXGotY, DominicanRepublicIbanLength, normalized.Length));
+        }
+
+        if (!normalized.StartsWith(DominicanRepublicCountryCode, StringComparison.OrdinalIgnoreCase))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidCountryCode, ValidationMessages.InvalidCountryCode);
+        }
+
+        // Validate BBAN format: 4 letters (bank code) + 20 digits (account)
+        string bban = normalized.Substring(4);
+
+        // Bank code (4 letters)
+        if (!bban.Substring(0, 4).All(char.IsLetter))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidFormat, ValidationMessages.InvalidFormat);
+        }
+
+        // Account number (20 digits)
+        if (!bban.Substring(4).All(char.IsDigit))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidFormat, ValidationMessages.InvalidFormat);
+        }
+
+        return IbanHelper.IsValidIban(normalized)
+            ? ValidationResult.Success()
+            : ValidationResult.Failure(ValidationErrorCode.InvalidChecksum, ValidationMessages.InvalidChecksum);
+    }
+}

--- a/src/Finova/Countries/NorthAmerica/ElSalvador/Validators/ElSalvadorIbanValidator.cs
+++ b/src/Finova/Countries/NorthAmerica/ElSalvador/Validators/ElSalvadorIbanValidator.cs
@@ -1,0 +1,61 @@
+using System.Diagnostics.CodeAnalysis;
+using Finova.Core.Common;
+using Finova.Core.Iban;
+
+namespace Finova.Countries.NorthAmerica.ElSalvador.Validators;
+
+/// <summary>
+/// Validator for El Salvador IBANs.
+/// El Salvador IBAN format: SV + 2 check digits + 4 letters (bank code) + 20 digits (account)
+/// Length: 28 characters
+/// Example: SV62CENR00000000000000700025
+/// </summary>
+public class ElSalvadorIbanValidator : IIbanValidator
+{
+    public string CountryCode => "SV";
+
+    private const int ElSalvadorIbanLength = 28;
+    private const string ElSalvadorCountryCode = "SV";
+
+    public ValidationResult Validate(string? iban) => ValidateElSalvadorIban(iban);
+
+    public static ValidationResult ValidateElSalvadorIban([NotNullWhen(true)] string? iban)
+    {
+        if (string.IsNullOrWhiteSpace(iban))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidInput, ValidationMessages.InputCannotBeEmpty);
+        }
+
+        var normalized = IbanHelper.NormalizeIban(iban);
+
+        if (normalized.Length != ElSalvadorIbanLength)
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidLength,
+                string.Format(ValidationMessages.InvalidLengthExpectedXGotY, ElSalvadorIbanLength, normalized.Length));
+        }
+
+        if (!normalized.StartsWith(ElSalvadorCountryCode, StringComparison.OrdinalIgnoreCase))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidCountryCode, ValidationMessages.InvalidCountryCode);
+        }
+
+        // Validate BBAN format: 4 letters (bank code) + 20 digits (account)
+        string bban = normalized.Substring(4);
+
+        // Bank code (4 letters)
+        if (!bban.Substring(0, 4).All(char.IsLetter))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidFormat, ValidationMessages.InvalidFormat);
+        }
+
+        // Account number (20 digits)
+        if (!bban.Substring(4).All(char.IsDigit))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidFormat, ValidationMessages.InvalidFormat);
+        }
+
+        return IbanHelper.IsValidIban(normalized)
+            ? ValidationResult.Success()
+            : ValidationResult.Failure(ValidationErrorCode.InvalidChecksum, ValidationMessages.InvalidChecksum);
+    }
+}

--- a/src/Finova/Countries/NorthAmerica/Guatemala/Validators/GuatemalaIbanValidator.cs
+++ b/src/Finova/Countries/NorthAmerica/Guatemala/Validators/GuatemalaIbanValidator.cs
@@ -1,0 +1,61 @@
+using System.Diagnostics.CodeAnalysis;
+using Finova.Core.Common;
+using Finova.Core.Iban;
+
+namespace Finova.Countries.NorthAmerica.Guatemala.Validators;
+
+/// <summary>
+/// Validator for Guatemala IBANs.
+/// Guatemala IBAN format: GT + 2 check digits + 4 letters (bank code) + 20 alphanumeric (account)
+/// Length: 28 characters
+/// Example: GT82TRAJ01020000001210029690
+/// </summary>
+public class GuatemalaIbanValidator : IIbanValidator
+{
+    public string CountryCode => "GT";
+
+    private const int GuatemalaIbanLength = 28;
+    private const string GuatemalaCountryCode = "GT";
+
+    public ValidationResult Validate(string? iban) => ValidateGuatemalaIban(iban);
+
+    public static ValidationResult ValidateGuatemalaIban([NotNullWhen(true)] string? iban)
+    {
+        if (string.IsNullOrWhiteSpace(iban))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidInput, ValidationMessages.InputCannotBeEmpty);
+        }
+
+        var normalized = IbanHelper.NormalizeIban(iban);
+
+        if (normalized.Length != GuatemalaIbanLength)
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidLength,
+                string.Format(ValidationMessages.InvalidLengthExpectedXGotY, GuatemalaIbanLength, normalized.Length));
+        }
+
+        if (!normalized.StartsWith(GuatemalaCountryCode, StringComparison.OrdinalIgnoreCase))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidCountryCode, ValidationMessages.InvalidCountryCode);
+        }
+
+        // Validate BBAN format: 4 letters (bank code) + 20 alphanumeric (account)
+        string bban = normalized.Substring(4);
+
+        // Bank code (4 letters)
+        if (!bban.Substring(0, 4).All(char.IsLetter))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidFormat, ValidationMessages.InvalidFormat);
+        }
+
+        // Account number (20 alphanumeric)
+        if (!bban.Substring(4).All(char.IsLetterOrDigit))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidFormat, ValidationMessages.InvalidFormat);
+        }
+
+        return IbanHelper.IsValidIban(normalized)
+            ? ValidationResult.Success()
+            : ValidationResult.Failure(ValidationErrorCode.InvalidChecksum, ValidationMessages.InvalidChecksum);
+    }
+}

--- a/src/Finova/Countries/NorthAmerica/VirginIslandsBritish/Validators/VirginIslandsBritishIbanValidator.cs
+++ b/src/Finova/Countries/NorthAmerica/VirginIslandsBritish/Validators/VirginIslandsBritishIbanValidator.cs
@@ -1,0 +1,61 @@
+using System.Diagnostics.CodeAnalysis;
+using Finova.Core.Common;
+using Finova.Core.Iban;
+
+namespace Finova.Countries.NorthAmerica.VirginIslandsBritish.Validators;
+
+/// <summary>
+/// Validator for British Virgin Islands IBANs.
+/// British Virgin Islands IBAN format: VG + 2 check digits + 4 letters (bank code) + 16 digits (account)
+/// Length: 24 characters
+/// Example: VG96VPVG0000012345678901
+/// </summary>
+public class VirginIslandsBritishIbanValidator : IIbanValidator
+{
+    public string CountryCode => "VG";
+
+    private const int VirginIslandsBritishIbanLength = 24;
+    private const string VirginIslandsBritishCountryCode = "VG";
+
+    public ValidationResult Validate(string? iban) => ValidateVirginIslandsBritishIban(iban);
+
+    public static ValidationResult ValidateVirginIslandsBritishIban([NotNullWhen(true)] string? iban)
+    {
+        if (string.IsNullOrWhiteSpace(iban))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidInput, ValidationMessages.InputCannotBeEmpty);
+        }
+
+        var normalized = IbanHelper.NormalizeIban(iban);
+
+        if (normalized.Length != VirginIslandsBritishIbanLength)
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidLength,
+                string.Format(ValidationMessages.InvalidLengthExpectedXGotY, VirginIslandsBritishIbanLength, normalized.Length));
+        }
+
+        if (!normalized.StartsWith(VirginIslandsBritishCountryCode, StringComparison.OrdinalIgnoreCase))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidCountryCode, ValidationMessages.InvalidCountryCode);
+        }
+
+        // Validate BBAN format: 4 letters (bank code) + 16 digits (account)
+        string bban = normalized.Substring(4);
+
+        // Bank code (4 letters)
+        if (!bban.Substring(0, 4).All(char.IsLetter))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidFormat, ValidationMessages.InvalidFormat);
+        }
+
+        // Account number (16 digits)
+        if (!bban.Substring(4).All(char.IsDigit))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidFormat, ValidationMessages.InvalidFormat);
+        }
+
+        return IbanHelper.IsValidIban(normalized)
+            ? ValidationResult.Success()
+            : ValidationResult.Failure(ValidationErrorCode.InvalidChecksum, ValidationMessages.InvalidChecksum);
+    }
+}

--- a/src/Finova/Countries/SouthAmerica/Brazil/Validators/BrazilIbanValidator.cs
+++ b/src/Finova/Countries/SouthAmerica/Brazil/Validators/BrazilIbanValidator.cs
@@ -1,0 +1,75 @@
+using System.Diagnostics.CodeAnalysis;
+using Finova.Core.Common;
+using Finova.Core.Iban;
+
+namespace Finova.Countries.SouthAmerica.Brazil.Validators;
+
+/// <summary>
+/// Validator for Brazil IBANs.
+/// Brazil IBAN format: BR + 2 check digits + 8 digits (bank code) + 5 digits (branch) + 10 digits (account) + 1 letter (account type) + 1 letter (owner)
+/// Length: 29 characters
+/// Example: BR1800360305000010009795493C1
+/// </summary>
+public class BrazilIbanValidator : IIbanValidator
+{
+    public string CountryCode => "BR";
+
+    private const int BrazilIbanLength = 29;
+    private const string BrazilCountryCode = "BR";
+
+    public ValidationResult Validate(string? iban) => ValidateBrazilIban(iban);
+
+    public static ValidationResult ValidateBrazilIban([NotNullWhen(true)] string? iban)
+    {
+        if (string.IsNullOrWhiteSpace(iban))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidInput, ValidationMessages.InputCannotBeEmpty);
+        }
+
+        var normalized = IbanHelper.NormalizeIban(iban);
+
+        if (normalized.Length != BrazilIbanLength)
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidLength,
+                string.Format(ValidationMessages.InvalidLengthExpectedXGotY, BrazilIbanLength, normalized.Length));
+        }
+
+        if (!normalized.StartsWith(BrazilCountryCode, StringComparison.OrdinalIgnoreCase))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidCountryCode, ValidationMessages.InvalidCountryCode);
+        }
+
+        // Validate BBAN format: 8 digits (bank code) + 5 digits (branch) + 10 digits (account) + 1 letter (type) + 1 letter (owner)
+        string bban = normalized.Substring(4);
+
+        // Bank code (8 digits)
+        if (!bban.Substring(0, 8).All(char.IsDigit))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidFormat, ValidationMessages.InvalidFormat);
+        }
+
+        // Branch code (5 digits)
+        if (!bban.Substring(8, 5).All(char.IsDigit))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidFormat, ValidationMessages.InvalidFormat);
+        }
+
+        // Account number (10 digits)
+        if (!bban.Substring(13, 10).All(char.IsDigit))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidFormat, ValidationMessages.InvalidFormat);
+        }
+
+        // Account type (1 letter) and Owner indicator (1 letter)
+        string accountType = bban.Substring(23, 1);
+        string ownerIndicator = bban.Substring(24, 1);
+        if (!char.IsLetter(accountType[0]) || !char.IsLetterOrDigit(ownerIndicator[0]))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidFormat, ValidationMessages.InvalidFormat);
+        }
+
+        return IbanHelper.IsValidIban(normalized)
+            ? ValidationResult.Success()
+            : ValidationResult.Failure(ValidationErrorCode.InvalidChecksum, ValidationMessages.InvalidChecksum);
+    }
+}

--- a/src/Finova/Extensions/DependencyInjection/AfricaServiceCollectionExtensions.cs
+++ b/src/Finova/Extensions/DependencyInjection/AfricaServiceCollectionExtensions.cs
@@ -1,6 +1,9 @@
+using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using Finova.Core.Identifiers;
+using Finova.Core.Iban;
 using Finova.Services;
+using Finova.Services.Adapters;
 using Finova.Countries.Africa.SouthAfrica.Validators;
 using Finova.Countries.Africa.Egypt.Validators;
 using Finova.Countries.Africa.Nigeria.Validators;
@@ -11,17 +14,28 @@ namespace Finova.Extensions.DependencyInjection;
 public static class AfricaServiceCollectionExtensions
 {
     /// <summary>
-    /// Registers African financial validators (South Africa, Nigeria, Kenya, Egypt).
+    /// Registers African financial validators (South Africa, Nigeria, Kenya, Egypt, Mauritania).
     /// </summary>
     public static IServiceCollection AddFinovaAfrica(this IServiceCollection services)
     {
+        var assembly = Assembly.GetAssembly(typeof(AfricaServiceCollectionExtensions)) ?? Assembly.GetExecutingAssembly();
+
         services.RegisterValidatorsFromNamespace(
-            typeof(AfricaServiceCollectionExtensions).Assembly,
+            assembly,
             "Finova.Countries.Africa",
-            null,
+            (s, type) =>
+            {
+                // Special handling for IBAN validators to register IBankAccountValidator adapter
+                if (typeof(IIbanValidator).IsAssignableFrom(type))
+                {
+                    s.AddSingleton<IBankAccountValidator>(sp =>
+                        new EuropeIbanBankAccountAdapter((IIbanValidator)sp.GetRequiredService(type)));
+                }
+            },
             typeof(ITaxIdValidator),
             typeof(INationalIdValidator),
-            typeof(IBankRoutingValidator)
+            typeof(IBankRoutingValidator),
+            typeof(IIbanValidator)
         );
 
         services.AddSingleton<INationalIdValidator, SouthAfricaIdValidator>();

--- a/src/Finova/Extensions/DependencyInjection/AsiaServiceCollectionExtensions.cs
+++ b/src/Finova/Extensions/DependencyInjection/AsiaServiceCollectionExtensions.cs
@@ -1,14 +1,16 @@
 using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using Finova.Core.Identifiers;
+using Finova.Core.Iban;
 using Finova.Services;
+using Finova.Services.Adapters;
 
 namespace Finova.Extensions.DependencyInjection;
 
 public static class AsiaServiceCollectionExtensions
 {
     /// <summary>
-    /// Registers Asian financial validators (China, India, Japan, Singapore).
+    /// Registers Asian financial validators (China, India, Japan, Singapore, Kazakhstan, Pakistan, Timor-Leste).
     /// </summary>
     public static IServiceCollection AddFinovaAsia(this IServiceCollection services)
     {
@@ -16,15 +18,24 @@ public static class AsiaServiceCollectionExtensions
 
         // Auto-register all validators under the Finova.Countries.Asia namespace
         var assembly = Assembly.GetAssembly(typeof(AsiaServiceCollectionExtensions)) ?? Assembly.GetExecutingAssembly();
-        
+
         services.RegisterValidatorsFromNamespace(
-            assembly, 
+            assembly,
             "Finova.Countries.Asia",
-            null, // No special adapters needed for Asia yet
+            (s, type) =>
+            {
+                // Special handling for IBAN validators to register IBankAccountValidator adapter
+                if (typeof(IIbanValidator).IsAssignableFrom(type))
+                {
+                    s.AddSingleton<IBankAccountValidator>(sp =>
+                        new EuropeIbanBankAccountAdapter((IIbanValidator)sp.GetRequiredService(type)));
+                }
+            },
             typeof(ITaxIdValidator),
             typeof(INationalIdValidator),
             typeof(IBankRoutingValidator),
-            typeof(IBankAccountValidator)
+            typeof(IBankAccountValidator),
+            typeof(IIbanValidator)
         );
 
         return services;

--- a/src/Finova/Extensions/DependencyInjection/MiddleEastServiceCollectionExtensions.cs
+++ b/src/Finova/Extensions/DependencyInjection/MiddleEastServiceCollectionExtensions.cs
@@ -1,6 +1,9 @@
+using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using Finova.Core.Identifiers;
+using Finova.Core.Iban;
 using Finova.Services;
+using Finova.Services.Adapters;
 using Finova.Countries.MiddleEast.Israel.Validators;
 using Finova.Countries.MiddleEast.UAE.Validators;
 using Finova.Countries.MiddleEast.SaudiArabia.Validators;
@@ -10,17 +13,28 @@ namespace Finova.Extensions.DependencyInjection;
 public static class MiddleEastServiceCollectionExtensions
 {
     /// <summary>
-    /// Registers Middle East financial validators (Israel, UAE, Saudi Arabia).
+    /// Registers Middle East financial validators (Israel, UAE, Saudi Arabia, Bahrain, Jordan, Kuwait, Lebanon, Qatar).
     /// </summary>
     public static IServiceCollection AddFinovaMiddleEast(this IServiceCollection services)
     {
+        var assembly = Assembly.GetAssembly(typeof(MiddleEastServiceCollectionExtensions)) ?? Assembly.GetExecutingAssembly();
+
         services.RegisterValidatorsFromNamespace(
-            typeof(MiddleEastServiceCollectionExtensions).Assembly,
+            assembly,
             "Finova.Countries.MiddleEast",
-            null,
+            (s, type) =>
+            {
+                // Special handling for IBAN validators to register IBankAccountValidator adapter
+                if (typeof(IIbanValidator).IsAssignableFrom(type))
+                {
+                    s.AddSingleton<IBankAccountValidator>(sp =>
+                        new EuropeIbanBankAccountAdapter((IIbanValidator)sp.GetRequiredService(type)));
+                }
+            },
             typeof(ITaxIdValidator),
             typeof(INationalIdValidator),
-            typeof(IBankRoutingValidator)
+            typeof(IBankRoutingValidator),
+            typeof(IIbanValidator)
         );
 
         services.AddSingleton<INationalIdValidator, IsraelTeudatZehutValidator>();

--- a/src/Finova/Extensions/DependencyInjection/NorthAmericaServiceCollectionExtensions.cs
+++ b/src/Finova/Extensions/DependencyInjection/NorthAmericaServiceCollectionExtensions.cs
@@ -1,26 +1,40 @@
+using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using Finova.Core.Identifiers;
+using Finova.Core.Iban;
 using Finova.Services;
+using Finova.Services.Adapters;
 
 namespace Finova.Extensions.DependencyInjection;
 
 public static class NorthAmericaServiceCollectionExtensions
 {
     /// <summary>
-    /// Registers North American financial validators (USA, Canada).
+    /// Registers North American financial validators (USA, Canada, Costa Rica, Dominican Republic, El Salvador, Guatemala, Virgin Islands British).
     /// </summary>
     public static IServiceCollection AddFinovaNorthAmerica(this IServiceCollection services)
     {
         services.AddSingleton<NorthAmericaBankValidator>();
 
+        var assembly = Assembly.GetAssembly(typeof(NorthAmericaServiceCollectionExtensions)) ?? Assembly.GetExecutingAssembly();
+
         services.RegisterValidatorsFromNamespace(
-            typeof(NorthAmericaServiceCollectionExtensions).Assembly,
+            assembly,
             "Finova.Countries.NorthAmerica",
-            null, // No special adapters needed beyond standard interfaces
+            (s, type) =>
+            {
+                // Special handling for IBAN validators to register IBankAccountValidator adapter
+                if (typeof(IIbanValidator).IsAssignableFrom(type))
+                {
+                    s.AddSingleton<IBankAccountValidator>(sp =>
+                        new EuropeIbanBankAccountAdapter((IIbanValidator)sp.GetRequiredService(type)));
+                }
+            },
             typeof(ITaxIdValidator),
             typeof(INationalIdValidator),
             typeof(IBankRoutingValidator),
-            typeof(IBankRoutingParser)
+            typeof(IBankRoutingParser),
+            typeof(IIbanValidator)
         );
 
         return services;

--- a/src/Finova/Extensions/DependencyInjection/SouthAmericaServiceCollectionExtensions.cs
+++ b/src/Finova/Extensions/DependencyInjection/SouthAmericaServiceCollectionExtensions.cs
@@ -1,6 +1,9 @@
+using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using Finova.Core.Identifiers;
+using Finova.Core.Iban;
 using Finova.Services;
+using Finova.Services.Adapters;
 using Finova.Countries.SouthAmerica.Colombia.Validators;
 
 namespace Finova.Extensions.DependencyInjection;
@@ -8,17 +11,28 @@ namespace Finova.Extensions.DependencyInjection;
 public static class SouthAmericaServiceCollectionExtensions
 {
     /// <summary>
-    /// Registers South American financial validators (Brazil, Mexico, Colombia).
+    /// Registers South American financial validators (Brazil, Colombia).
     /// </summary>
     public static IServiceCollection AddFinovaSouthAmerica(this IServiceCollection services)
     {
+        var assembly = Assembly.GetAssembly(typeof(SouthAmericaServiceCollectionExtensions)) ?? Assembly.GetExecutingAssembly();
+
         services.RegisterValidatorsFromNamespace(
-            typeof(SouthAmericaServiceCollectionExtensions).Assembly,
+            assembly,
             "Finova.Countries.SouthAmerica",
-            null,
+            (s, type) =>
+            {
+                // Special handling for IBAN validators to register IBankAccountValidator adapter
+                if (typeof(IIbanValidator).IsAssignableFrom(type))
+                {
+                    s.AddSingleton<IBankAccountValidator>(sp =>
+                        new EuropeIbanBankAccountAdapter((IIbanValidator)sp.GetRequiredService(type)));
+                }
+            },
             typeof(ITaxIdValidator),
             typeof(INationalIdValidator),
-            typeof(IBankRoutingValidator)
+            typeof(IBankRoutingValidator),
+            typeof(IIbanValidator)
         );
 
         services.AddSingleton<INationalIdValidator, ColombiaCedulaValidator>();

--- a/src/Finova/Services/Europe/EuropeIbanValidator.cs
+++ b/src/Finova/Services/Europe/EuropeIbanValidator.cs
@@ -1,6 +1,8 @@
 using Finova.Core.Iban;
 using Finova.Countries.Europe.Andorra.Validators;
 using Finova.Countries.Europe.Austria.Validators;
+using Finova.Countries.Europe.Azerbaijan.Validators;
+using Finova.Countries.Europe.Belarus.Validators;
 using Finova.Countries.Europe.Belgium.Validators;
 using Finova.Countries.Europe.Bulgaria.Validators;
 using Finova.Countries.Europe.Croatia.Validators;
@@ -8,19 +10,23 @@ using Finova.Countries.Europe.Cyprus.Validators;
 using Finova.Countries.Europe.CzechRepublic.Validators;
 using Finova.Countries.Europe.Denmark.Validators;
 using Finova.Countries.Europe.Estonia.Validators;
+using Finova.Countries.Europe.FaroeIslands.Validators;
 using Finova.Countries.Europe.Finland.Validators;
 using Finova.Countries.Europe.France.Validators;
 using Finova.Countries.Europe.Germany.Validators;
 using Finova.Countries.Europe.Gibraltar.Validators;
 using Finova.Countries.Europe.Greece.Validators;
+using Finova.Countries.Europe.Greenland.Validators;
 using Finova.Countries.Europe.Hungary.Validators;
 using Finova.Countries.Europe.Iceland.Validators;
 using Finova.Countries.Europe.Ireland.Validators;
 using Finova.Countries.Europe.Italy.Validators;
+using Finova.Countries.Europe.Kosovo.Validators;
 using Finova.Countries.Europe.Latvia.Validators;
 using Finova.Countries.Europe.Lithuania.Validators;
 using Finova.Countries.Europe.Luxembourg.Validators;
 using Finova.Countries.Europe.Malta.Validators;
+using Finova.Countries.Europe.Moldova.Validators;
 using Finova.Countries.Europe.Monaco.Validators;
 using Finova.Countries.Europe.Netherlands.Validators;
 using Finova.Countries.Europe.Norway.Validators;
@@ -173,10 +179,17 @@ public class EuropeIbanValidator : IIbanValidator
             "MK" => NorthMacedoniaIbanValidator.ValidateNorthMacedoniaIban(iban),
             "BA" => BosniaAndHerzegovinaIbanValidator.ValidateBosniaAndHerzegovinaIban(iban),
             "GE" => GeorgiaIbanValidator.ValidateGeorgiaIban(iban),
+            // Additional European territories and countries
+            "FO" => FaroeIslandsIbanValidator.ValidateFaroeIslandsIban(iban),
+            "GL" => GreenlandIbanValidator.ValidateGreenlandIban(iban),
+            "XK" => KosovoIbanValidator.ValidateKosovoIban(iban),
+            "MD" => MoldovaIbanValidator.ValidateMoldovaIban(iban),
+            "BY" => BelarusIbanValidator.ValidateBelarusIban(iban),
+            "AZ" => AzerbaijanIbanValidator.ValidateAzerbaijanIban(iban),
 
             _ => IbanHelper.IsValidIban(iban)
                 ? ValidationResult.Success()
-                : ValidationResult.Failure(ValidationErrorCode.UnsupportedCountry, $"Country code {country} is not supported or IBAN is invalid.")
+                : ValidationResult.Failure(ValidationErrorCode.UnsupportedCountry, ValidationMessages.UnsupportedCountryOrInvalidIban)
         };
     }
 }

--- a/src/Finova/Services/Global/GlobalIbanValidator.cs
+++ b/src/Finova/Services/Global/GlobalIbanValidator.cs
@@ -1,0 +1,110 @@
+using Finova.Core.Iban;
+using Finova.Core.Common;
+
+// Middle East
+using Finova.Countries.MiddleEast.Bahrain.Validators;
+using Finova.Countries.MiddleEast.Israel.Validators;
+using Finova.Countries.MiddleEast.Jordan.Validators;
+using Finova.Countries.MiddleEast.Kuwait.Validators;
+using Finova.Countries.MiddleEast.Lebanon.Validators;
+using Finova.Countries.MiddleEast.Qatar.Validators;
+using Finova.Countries.MiddleEast.SaudiArabia.Validators;
+using Finova.Countries.MiddleEast.UAE.Validators;
+
+// Africa
+using Finova.Countries.Africa.Egypt.Validators;
+using Finova.Countries.Africa.Mauritania.Validators;
+
+// Americas
+using Finova.Countries.SouthAmerica.Brazil.Validators;
+using Finova.Countries.NorthAmerica.CostaRica.Validators;
+using Finova.Countries.NorthAmerica.DominicanRepublic.Validators;
+using Finova.Countries.NorthAmerica.ElSalvador.Validators;
+using Finova.Countries.NorthAmerica.Guatemala.Validators;
+using Finova.Countries.NorthAmerica.VirginIslandsBritish.Validators;
+
+// Asia
+using Finova.Countries.Asia.Kazakhstan.Validators;
+using Finova.Countries.Asia.Pakistan.Validators;
+using Finova.Countries.Asia.TimorLeste.Validators;
+
+namespace Finova.Services;
+
+/// <summary>
+/// Global IBAN validator that supports all IBAN-enabled countries worldwide.
+/// Routes validation to regional validators (Europe, Middle East, Africa, Americas, Asia).
+/// </summary>
+/// <example>
+/// <code>
+/// // Validate any IBAN worldwide
+/// var result = GlobalIbanValidator.ValidateIban("BR1800360305000010009795493C1");
+///
+/// // European IBANs are routed to EuropeIbanValidator
+/// var resultEu = GlobalIbanValidator.ValidateIban("DE89370400440532013000");
+/// </code>
+/// </example>
+public static class GlobalIbanValidator
+{
+    /// <summary>
+    /// Validates an IBAN from any supported country.
+    /// </summary>
+    /// <param name="iban">The IBAN to validate.</param>
+    /// <returns>A ValidationResult indicating success or failure with detailed error information.</returns>
+    public static ValidationResult ValidateIban(string? iban)
+    {
+        if (string.IsNullOrWhiteSpace(iban))
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidInput, ValidationMessages.InputCannotBeEmpty);
+        }
+
+        if (iban.Length < 2)
+        {
+            return ValidationResult.Failure(ValidationErrorCode.InvalidInput, ValidationMessages.InvalidLength);
+        }
+
+        string country = IbanHelper.NormalizeIban(iban)[0..2].ToUpperInvariant();
+
+        return country switch
+        {
+            // ===== EUROPE (delegated to EuropeIbanValidator) =====
+            "AL" or "AD" or "AT" or "AZ" or "BA" or "BY" or "BE" or "BG" or "HR" or "CY" or
+            "CZ" or "DK" or "EE" or "FO" or "FI" or "FR" or "GE" or "DE" or "GI" or "GR" or
+            "GL" or "HU" or "IS" or "IE" or "IT" or "XK" or "LV" or "LI" or "LT" or "LU" or
+            "MK" or "MT" or "MD" or "MC" or "ME" or "NL" or "NO" or "PL" or "PT" or "RO" or
+            "SM" or "RS" or "SK" or "SI" or "ES" or "SE" or "CH" or "TR" or "UA" or "GB" or "VA"
+                => EuropeIbanValidator.ValidateIban(iban),
+
+            // ===== MIDDLE EAST =====
+            "BH" => BahrainIbanValidator.ValidateBahrainIban(iban),
+            "IL" => IsraelIbanValidator.ValidateIsraelIban(iban),
+            "JO" => JordanIbanValidator.ValidateJordanIban(iban),
+            "KW" => KuwaitIbanValidator.ValidateKuwaitIban(iban),
+            "LB" => LebanonIbanValidator.ValidateLebanonIban(iban),
+            "QA" => QatarIbanValidator.ValidateQatarIban(iban),
+            "SA" => SaudiArabiaIbanValidator.ValidateSaudiArabiaIban(iban),
+            "AE" => UAEIbanValidator.ValidateUAEIban(iban),
+
+            // ===== AFRICA =====
+            "EG" => EgyptIbanValidator.ValidateEgyptIban(iban),
+            "MR" => MauritaniaIbanValidator.ValidateMauritaniaIban(iban),
+
+            // ===== AMERICAS =====
+            "BR" => BrazilIbanValidator.ValidateBrazilIban(iban),
+            "CR" => CostaRicaIbanValidator.ValidateCostaRicaIban(iban),
+            "DO" => DominicanRepublicIbanValidator.ValidateDominicanRepublicIban(iban),
+            "SV" => ElSalvadorIbanValidator.ValidateElSalvadorIban(iban),
+            "GT" => GuatemalaIbanValidator.ValidateGuatemalaIban(iban),
+            "VG" => VirginIslandsBritishIbanValidator.ValidateVirginIslandsBritishIban(iban),
+
+            // ===== ASIA =====
+            "KZ" => KazakhstanIbanValidator.ValidateKazakhstanIban(iban),
+            "PK" => PakistanIbanValidator.ValidatePakistanIban(iban),
+            "TL" => TimorLesteIbanValidator.ValidateTimorLesteIban(iban),
+
+            // ===== FALLBACK =====
+            _ => IbanHelper.IsValidIban(iban)
+                ? ValidationResult.Success()
+                : ValidationResult.Failure(ValidationErrorCode.UnsupportedCountry, ValidationMessages.UnsupportedCountryOrInvalidIban)
+        };
+    }
+}

--- a/tests/Finova.Tests/Countries/Africa/Egypt/Validators/EgyptIbanValidatorTests.cs
+++ b/tests/Finova.Tests/Countries/Africa/Egypt/Validators/EgyptIbanValidatorTests.cs
@@ -1,0 +1,39 @@
+using Finova.Countries.Africa.Egypt.Validators;
+using FluentAssertions;
+using Xunit;
+
+namespace Finova.Tests.Countries.Africa.Egypt.Validators;
+
+public class EgyptIbanValidatorTests
+{
+    private readonly EgyptIbanValidator _validator = new();
+
+    [Fact]
+    public void CountryCode_ReturnsEG() => _validator.CountryCode.Should().Be("EG");
+
+    [Theory]
+    [InlineData("EG380019000500000000263180002")]
+    public void IsValidIban_WithValidEgyptIbans_ReturnsTrue(string iban)
+        => _validator.Validate(iban).IsValid.Should().BeTrue();
+
+    [Theory]
+    [InlineData("EG38 0019 0005 0000 0000 2631 8000 2")] // With spaces
+    [InlineData("eg380019000500000000263180002")] // Lowercase
+    public void IsValidIban_WithFormattedIbans_ReturnsTrue(string iban)
+        => _validator.Validate(iban).IsValid.Should().BeTrue();
+
+    [Theory]
+    [InlineData("EG000019000500000000263180002")] // Wrong check digits
+    [InlineData("DE89370400440532013000")] // Wrong country
+    [InlineData("EG3800190005000000002631800")] // Too short
+    [InlineData("EG38001900050000000026318000299")] // Too long
+    [InlineData("")] // Empty
+    [InlineData(null)] // Null
+    public void IsValidIban_WithInvalidIbans_ReturnsFalse(string? iban)
+        => _validator.Validate(iban).IsValid.Should().BeFalse();
+
+    [Theory]
+    [InlineData("EG380019000500000000263180002")]
+    public void ValidateEgyptIban_WithValidIbans_ReturnsTrue(string iban)
+        => EgyptIbanValidator.ValidateEgyptIban(iban).IsValid.Should().BeTrue();
+}

--- a/tests/Finova.Tests/Countries/Africa/Mauritania/Validators/MauritaniaIbanValidatorTests.cs
+++ b/tests/Finova.Tests/Countries/Africa/Mauritania/Validators/MauritaniaIbanValidatorTests.cs
@@ -1,0 +1,39 @@
+using Finova.Countries.Africa.Mauritania.Validators;
+using FluentAssertions;
+using Xunit;
+
+namespace Finova.Tests.Countries.Africa.Mauritania.Validators;
+
+public class MauritaniaIbanValidatorTests
+{
+    private readonly MauritaniaIbanValidator _validator = new();
+
+    [Fact]
+    public void CountryCode_ReturnsMR() => _validator.CountryCode.Should().Be("MR");
+
+    [Theory]
+    [InlineData("MR1300020001010000123456753")]
+    public void IsValidIban_WithValidMauritaniaIbans_ReturnsTrue(string iban)
+        => _validator.Validate(iban).IsValid.Should().BeTrue();
+
+    [Theory]
+    [InlineData("MR13 0002 0001 0100 0012 3456 753")] // With spaces
+    [InlineData("mr1300020001010000123456753")] // Lowercase
+    public void IsValidIban_WithFormattedIbans_ReturnsTrue(string iban)
+        => _validator.Validate(iban).IsValid.Should().BeTrue();
+
+    [Theory]
+    [InlineData("MR0000020001010000123456753")] // Wrong check digits
+    [InlineData("DE89370400440532013000")] // Wrong country
+    [InlineData("MR130002000101000012345")] // Too short
+    [InlineData("MR130002000101000012345675399")] // Too long
+    [InlineData("")] // Empty
+    [InlineData(null)] // Null
+    public void IsValidIban_WithInvalidIbans_ReturnsFalse(string? iban)
+        => _validator.Validate(iban).IsValid.Should().BeFalse();
+
+    [Theory]
+    [InlineData("MR1300020001010000123456753")]
+    public void ValidateMauritaniaIban_WithValidIbans_ReturnsTrue(string iban)
+        => MauritaniaIbanValidator.ValidateMauritaniaIban(iban).IsValid.Should().BeTrue();
+}

--- a/tests/Finova.Tests/Countries/Americas/Brazil/Validators/BrazilIbanValidatorTests.cs
+++ b/tests/Finova.Tests/Countries/Americas/Brazil/Validators/BrazilIbanValidatorTests.cs
@@ -1,0 +1,39 @@
+using Finova.Countries.SouthAmerica.Brazil.Validators;
+using FluentAssertions;
+using Xunit;
+
+namespace Finova.Tests.Countries.SouthAmerica.Brazil.Validators;
+
+public class BrazilIbanValidatorTests
+{
+    private readonly BrazilIbanValidator _validator = new();
+
+    [Fact]
+    public void CountryCode_ReturnsBR() => _validator.CountryCode.Should().Be("BR");
+
+    [Theory]
+    [InlineData("BR1800360305000010009795493C1")]
+    public void IsValidIban_WithValidBrazilIbans_ReturnsTrue(string iban)
+        => _validator.Validate(iban).IsValid.Should().BeTrue();
+
+    [Theory]
+    [InlineData("BR18 0036 0305 0000 1000 9795 493C 1")] // With spaces
+    [InlineData("br1800360305000010009795493c1")] // Lowercase
+    public void IsValidIban_WithFormattedIbans_ReturnsTrue(string iban)
+        => _validator.Validate(iban).IsValid.Should().BeTrue();
+
+    [Theory]
+    [InlineData("BR0000360305000010009795493C1")] // Wrong check digits
+    [InlineData("DE89370400440532013000")] // Wrong country
+    [InlineData("BR1800360305000010009795")] // Too short
+    [InlineData("BR1800360305000010009795493C1999")] // Too long
+    [InlineData("")] // Empty
+    [InlineData(null)] // Null
+    public void IsValidIban_WithInvalidIbans_ReturnsFalse(string? iban)
+        => _validator.Validate(iban).IsValid.Should().BeFalse();
+
+    [Theory]
+    [InlineData("BR1800360305000010009795493C1")]
+    public void ValidateBrazilIban_WithValidIbans_ReturnsTrue(string iban)
+        => BrazilIbanValidator.ValidateBrazilIban(iban).IsValid.Should().BeTrue();
+}

--- a/tests/Finova.Tests/Countries/Americas/CostaRica/Validators/CostaRicaIbanValidatorTests.cs
+++ b/tests/Finova.Tests/Countries/Americas/CostaRica/Validators/CostaRicaIbanValidatorTests.cs
@@ -1,0 +1,39 @@
+using Finova.Countries.NorthAmerica.CostaRica.Validators;
+using FluentAssertions;
+using Xunit;
+
+namespace Finova.Tests.Countries.NorthAmerica.CostaRica.Validators;
+
+public class CostaRicaIbanValidatorTests
+{
+    private readonly CostaRicaIbanValidator _validator = new();
+
+    [Fact]
+    public void CountryCode_ReturnsCR() => _validator.CountryCode.Should().Be("CR");
+
+    [Theory]
+    [InlineData("CR05015202001026284066")]
+    public void IsValidIban_WithValidCostaRicaIbans_ReturnsTrue(string iban)
+        => _validator.Validate(iban).IsValid.Should().BeTrue();
+
+    [Theory]
+    [InlineData("CR05 0152 0200 1026 2840 66")] // With spaces
+    [InlineData("cr05015202001026284066")] // Lowercase
+    public void IsValidIban_WithFormattedIbans_ReturnsTrue(string iban)
+        => _validator.Validate(iban).IsValid.Should().BeTrue();
+
+    [Theory]
+    [InlineData("CR00015202001026284066")] // Wrong check digits
+    [InlineData("DE89370400440532013000")] // Wrong country
+    [InlineData("CR0501520200102628")] // Too short
+    [InlineData("CR0501520200102628406699")] // Too long
+    [InlineData("")] // Empty
+    [InlineData(null)] // Null
+    public void IsValidIban_WithInvalidIbans_ReturnsFalse(string? iban)
+        => _validator.Validate(iban).IsValid.Should().BeFalse();
+
+    [Theory]
+    [InlineData("CR05015202001026284066")]
+    public void ValidateCostaRicaIban_WithValidIbans_ReturnsTrue(string iban)
+        => CostaRicaIbanValidator.ValidateCostaRicaIban(iban).IsValid.Should().BeTrue();
+}

--- a/tests/Finova.Tests/Countries/Americas/DominicanRepublic/Validators/DominicanRepublicIbanValidatorTests.cs
+++ b/tests/Finova.Tests/Countries/Americas/DominicanRepublic/Validators/DominicanRepublicIbanValidatorTests.cs
@@ -1,0 +1,39 @@
+using Finova.Countries.NorthAmerica.DominicanRepublic.Validators;
+using FluentAssertions;
+using Xunit;
+
+namespace Finova.Tests.Countries.NorthAmerica.DominicanRepublic.Validators;
+
+public class DominicanRepublicIbanValidatorTests
+{
+    private readonly DominicanRepublicIbanValidator _validator = new();
+
+    [Fact]
+    public void CountryCode_ReturnsDO() => _validator.CountryCode.Should().Be("DO");
+
+    [Theory]
+    [InlineData("DO22ACAU00000000000123456789")]
+    public void IsValidIban_WithValidDominicanRepublicIbans_ReturnsTrue(string iban)
+        => _validator.Validate(iban).IsValid.Should().BeTrue();
+
+    [Theory]
+    [InlineData("DO22 ACAU 0000 0000 0001 2345 6789")] // With spaces
+    [InlineData("do22acau00000000000123456789")] // Lowercase
+    public void IsValidIban_WithFormattedIbans_ReturnsTrue(string iban)
+        => _validator.Validate(iban).IsValid.Should().BeTrue();
+
+    [Theory]
+    [InlineData("DO00ACAU00000000000123456789")] // Wrong check digits
+    [InlineData("DE89370400440532013000")] // Wrong country
+    [InlineData("DO22ACAU000000000001234")] // Too short
+    [InlineData("DO22ACAU0000000000012345678999")] // Too long
+    [InlineData("")] // Empty
+    [InlineData(null)] // Null
+    public void IsValidIban_WithInvalidIbans_ReturnsFalse(string? iban)
+        => _validator.Validate(iban).IsValid.Should().BeFalse();
+
+    [Theory]
+    [InlineData("DO22ACAU00000000000123456789")]
+    public void ValidateDominicanRepublicIban_WithValidIbans_ReturnsTrue(string iban)
+        => DominicanRepublicIbanValidator.ValidateDominicanRepublicIban(iban).IsValid.Should().BeTrue();
+}

--- a/tests/Finova.Tests/Countries/Americas/ElSalvador/Validators/ElSalvadorIbanValidatorTests.cs
+++ b/tests/Finova.Tests/Countries/Americas/ElSalvador/Validators/ElSalvadorIbanValidatorTests.cs
@@ -1,0 +1,39 @@
+using Finova.Countries.NorthAmerica.ElSalvador.Validators;
+using FluentAssertions;
+using Xunit;
+
+namespace Finova.Tests.Countries.NorthAmerica.ElSalvador.Validators;
+
+public class ElSalvadorIbanValidatorTests
+{
+    private readonly ElSalvadorIbanValidator _validator = new();
+
+    [Fact]
+    public void CountryCode_ReturnsSV() => _validator.CountryCode.Should().Be("SV");
+
+    [Theory]
+    [InlineData("SV62CENR00000000000000700025")]
+    public void IsValidIban_WithValidElSalvadorIbans_ReturnsTrue(string iban)
+        => _validator.Validate(iban).IsValid.Should().BeTrue();
+
+    [Theory]
+    [InlineData("SV62 CENR 0000 0000 0000 0070 0025")] // With spaces
+    [InlineData("sv62cenr00000000000000700025")] // Lowercase
+    public void IsValidIban_WithFormattedIbans_ReturnsTrue(string iban)
+        => _validator.Validate(iban).IsValid.Should().BeTrue();
+
+    [Theory]
+    [InlineData("SV00CENR00000000000000700025")] // Wrong check digits
+    [InlineData("DE89370400440532013000")] // Wrong country
+    [InlineData("SV62CENR000000000000007")] // Too short
+    [InlineData("SV62CENR0000000000000070002599")] // Too long
+    [InlineData("")] // Empty
+    [InlineData(null)] // Null
+    public void IsValidIban_WithInvalidIbans_ReturnsFalse(string? iban)
+        => _validator.Validate(iban).IsValid.Should().BeFalse();
+
+    [Theory]
+    [InlineData("SV62CENR00000000000000700025")]
+    public void ValidateElSalvadorIban_WithValidIbans_ReturnsTrue(string iban)
+        => ElSalvadorIbanValidator.ValidateElSalvadorIban(iban).IsValid.Should().BeTrue();
+}

--- a/tests/Finova.Tests/Countries/Americas/Guatemala/Validators/GuatemalaIbanValidatorTests.cs
+++ b/tests/Finova.Tests/Countries/Americas/Guatemala/Validators/GuatemalaIbanValidatorTests.cs
@@ -1,0 +1,39 @@
+using Finova.Countries.NorthAmerica.Guatemala.Validators;
+using FluentAssertions;
+using Xunit;
+
+namespace Finova.Tests.Countries.NorthAmerica.Guatemala.Validators;
+
+public class GuatemalaIbanValidatorTests
+{
+    private readonly GuatemalaIbanValidator _validator = new();
+
+    [Fact]
+    public void CountryCode_ReturnsGT() => _validator.CountryCode.Should().Be("GT");
+
+    [Theory]
+    [InlineData("GT82TRAJ01020000001210029690")]
+    public void IsValidIban_WithValidGuatemalaIbans_ReturnsTrue(string iban)
+        => _validator.Validate(iban).IsValid.Should().BeTrue();
+
+    [Theory]
+    [InlineData("GT82 TRAJ 0102 0000 0012 1002 9690")] // With spaces
+    [InlineData("gt82traj01020000001210029690")] // Lowercase
+    public void IsValidIban_WithFormattedIbans_ReturnsTrue(string iban)
+        => _validator.Validate(iban).IsValid.Should().BeTrue();
+
+    [Theory]
+    [InlineData("GT00TRAJ01020000001210029690")] // Wrong check digits
+    [InlineData("DE89370400440532013000")] // Wrong country
+    [InlineData("GT82TRAJ0102000000121002")] // Too short
+    [InlineData("GT82TRAJ0102000000121002969099")] // Too long
+    [InlineData("")] // Empty
+    [InlineData(null)] // Null
+    public void IsValidIban_WithInvalidIbans_ReturnsFalse(string? iban)
+        => _validator.Validate(iban).IsValid.Should().BeFalse();
+
+    [Theory]
+    [InlineData("GT82TRAJ01020000001210029690")]
+    public void ValidateGuatemalaIban_WithValidIbans_ReturnsTrue(string iban)
+        => GuatemalaIbanValidator.ValidateGuatemalaIban(iban).IsValid.Should().BeTrue();
+}

--- a/tests/Finova.Tests/Countries/Americas/VirginIslandsBritish/Validators/VirginIslandsBritishIbanValidatorTests.cs
+++ b/tests/Finova.Tests/Countries/Americas/VirginIslandsBritish/Validators/VirginIslandsBritishIbanValidatorTests.cs
@@ -1,0 +1,39 @@
+using Finova.Countries.NorthAmerica.VirginIslandsBritish.Validators;
+using FluentAssertions;
+using Xunit;
+
+namespace Finova.Tests.Countries.NorthAmerica.VirginIslandsBritish.Validators;
+
+public class VirginIslandsBritishIbanValidatorTests
+{
+    private readonly VirginIslandsBritishIbanValidator _validator = new();
+
+    [Fact]
+    public void CountryCode_ReturnsVG() => _validator.CountryCode.Should().Be("VG");
+
+    [Theory]
+    [InlineData("VG96VPVG0000012345678901")]
+    public void IsValidIban_WithValidVirginIslandsIbans_ReturnsTrue(string iban)
+        => _validator.Validate(iban).IsValid.Should().BeTrue();
+
+    [Theory]
+    [InlineData("VG96 VPVG 0000 0123 4567 8901")] // With spaces
+    [InlineData("vg96vpvg0000012345678901")] // Lowercase
+    public void IsValidIban_WithFormattedIbans_ReturnsTrue(string iban)
+        => _validator.Validate(iban).IsValid.Should().BeTrue();
+
+    [Theory]
+    [InlineData("VG00VPVG0000012345678901")] // Wrong check digits
+    [InlineData("DE89370400440532013000")] // Wrong country
+    [InlineData("VG96VPVG00000123456")] // Too short
+    [InlineData("VG96VPVG000001234567890199")] // Too long
+    [InlineData("")] // Empty
+    [InlineData(null)] // Null
+    public void IsValidIban_WithInvalidIbans_ReturnsFalse(string? iban)
+        => _validator.Validate(iban).IsValid.Should().BeFalse();
+
+    [Theory]
+    [InlineData("VG96VPVG0000012345678901")]
+    public void ValidateVirginIslandsBritishIban_WithValidIbans_ReturnsTrue(string iban)
+        => VirginIslandsBritishIbanValidator.ValidateVirginIslandsBritishIban(iban).IsValid.Should().BeTrue();
+}

--- a/tests/Finova.Tests/Countries/Asia/Kazakhstan/Validators/KazakhstanIbanValidatorTests.cs
+++ b/tests/Finova.Tests/Countries/Asia/Kazakhstan/Validators/KazakhstanIbanValidatorTests.cs
@@ -1,0 +1,39 @@
+using Finova.Countries.Asia.Kazakhstan.Validators;
+using FluentAssertions;
+using Xunit;
+
+namespace Finova.Tests.Countries.Asia.Kazakhstan.Validators;
+
+public class KazakhstanIbanValidatorTests
+{
+    private readonly KazakhstanIbanValidator _validator = new();
+
+    [Fact]
+    public void CountryCode_ReturnsKZ() => _validator.CountryCode.Should().Be("KZ");
+
+    [Theory]
+    [InlineData("KZ86125KZT5004100100")]
+    public void IsValidIban_WithValidKazakhstanIbans_ReturnsTrue(string iban)
+        => _validator.Validate(iban).IsValid.Should().BeTrue();
+
+    [Theory]
+    [InlineData("KZ86 125K ZT50 0410 0100")] // With spaces
+    [InlineData("kz86125kzt5004100100")] // Lowercase
+    public void IsValidIban_WithFormattedIbans_ReturnsTrue(string iban)
+        => _validator.Validate(iban).IsValid.Should().BeTrue();
+
+    [Theory]
+    [InlineData("KZ00125KZT5004100100")] // Wrong check digits
+    [InlineData("DE89370400440532013000")] // Wrong country
+    [InlineData("KZ86125KZT50041")] // Too short
+    [InlineData("KZ86125KZT500410010099")] // Too long
+    [InlineData("")] // Empty
+    [InlineData(null)] // Null
+    public void IsValidIban_WithInvalidIbans_ReturnsFalse(string? iban)
+        => _validator.Validate(iban).IsValid.Should().BeFalse();
+
+    [Theory]
+    [InlineData("KZ86125KZT5004100100")]
+    public void ValidateKazakhstanIban_WithValidIbans_ReturnsTrue(string iban)
+        => KazakhstanIbanValidator.ValidateKazakhstanIban(iban).IsValid.Should().BeTrue();
+}

--- a/tests/Finova.Tests/Countries/Asia/Pakistan/Validators/PakistanIbanValidatorTests.cs
+++ b/tests/Finova.Tests/Countries/Asia/Pakistan/Validators/PakistanIbanValidatorTests.cs
@@ -1,0 +1,39 @@
+using Finova.Countries.Asia.Pakistan.Validators;
+using FluentAssertions;
+using Xunit;
+
+namespace Finova.Tests.Countries.Asia.Pakistan.Validators;
+
+public class PakistanIbanValidatorTests
+{
+    private readonly PakistanIbanValidator _validator = new();
+
+    [Fact]
+    public void CountryCode_ReturnsPK() => _validator.CountryCode.Should().Be("PK");
+
+    [Theory]
+    [InlineData("PK36SCBL0000001123456702")]
+    public void IsValidIban_WithValidPakistanIbans_ReturnsTrue(string iban)
+        => _validator.Validate(iban).IsValid.Should().BeTrue();
+
+    [Theory]
+    [InlineData("PK36 SCBL 0000 0011 2345 6702")] // With spaces
+    [InlineData("pk36scbl0000001123456702")] // Lowercase
+    public void IsValidIban_WithFormattedIbans_ReturnsTrue(string iban)
+        => _validator.Validate(iban).IsValid.Should().BeTrue();
+
+    [Theory]
+    [InlineData("PK00SCBL0000001123456702")] // Wrong check digits
+    [InlineData("DE89370400440532013000")] // Wrong country
+    [InlineData("PK36SCBL000000112345")] // Too short
+    [InlineData("PK36SCBL000000112345670299")] // Too long
+    [InlineData("")] // Empty
+    [InlineData(null)] // Null
+    public void IsValidIban_WithInvalidIbans_ReturnsFalse(string? iban)
+        => _validator.Validate(iban).IsValid.Should().BeFalse();
+
+    [Theory]
+    [InlineData("PK36SCBL0000001123456702")]
+    public void ValidatePakistanIban_WithValidIbans_ReturnsTrue(string iban)
+        => PakistanIbanValidator.ValidatePakistanIban(iban).IsValid.Should().BeTrue();
+}

--- a/tests/Finova.Tests/Countries/Asia/TimorLeste/Validators/TimorLesteIbanValidatorTests.cs
+++ b/tests/Finova.Tests/Countries/Asia/TimorLeste/Validators/TimorLesteIbanValidatorTests.cs
@@ -1,0 +1,39 @@
+using Finova.Countries.Asia.TimorLeste.Validators;
+using FluentAssertions;
+using Xunit;
+
+namespace Finova.Tests.Countries.Asia.TimorLeste.Validators;
+
+public class TimorLesteIbanValidatorTests
+{
+    private readonly TimorLesteIbanValidator _validator = new();
+
+    [Fact]
+    public void CountryCode_ReturnsTL() => _validator.CountryCode.Should().Be("TL");
+
+    [Theory]
+    [InlineData("TL380080012345678910157")]
+    public void IsValidIban_WithValidTimorLesteIbans_ReturnsTrue(string iban)
+        => _validator.Validate(iban).IsValid.Should().BeTrue();
+
+    [Theory]
+    [InlineData("TL38 0080 0123 4567 8910 157")] // With spaces
+    [InlineData("tl380080012345678910157")] // Lowercase
+    public void IsValidIban_WithFormattedIbans_ReturnsTrue(string iban)
+        => _validator.Validate(iban).IsValid.Should().BeTrue();
+
+    [Theory]
+    [InlineData("TL000080012345678910157")] // Wrong check digits
+    [InlineData("DE89370400440532013000")] // Wrong country
+    [InlineData("TL3800800123456789")] // Too short
+    [InlineData("TL38008001234567891015799")] // Too long
+    [InlineData("")] // Empty
+    [InlineData(null)] // Null
+    public void IsValidIban_WithInvalidIbans_ReturnsFalse(string? iban)
+        => _validator.Validate(iban).IsValid.Should().BeFalse();
+
+    [Theory]
+    [InlineData("TL380080012345678910157")]
+    public void ValidateTimorLesteIban_WithValidIbans_ReturnsTrue(string iban)
+        => TimorLesteIbanValidator.ValidateTimorLesteIban(iban).IsValid.Should().BeTrue();
+}

--- a/tests/Finova.Tests/Countries/MiddleEast/Bahrain/Validators/BahrainIbanValidatorTests.cs
+++ b/tests/Finova.Tests/Countries/MiddleEast/Bahrain/Validators/BahrainIbanValidatorTests.cs
@@ -1,0 +1,39 @@
+using Finova.Countries.MiddleEast.Bahrain.Validators;
+using FluentAssertions;
+using Xunit;
+
+namespace Finova.Tests.Countries.MiddleEast.Bahrain.Validators;
+
+public class BahrainIbanValidatorTests
+{
+    private readonly BahrainIbanValidator _validator = new();
+
+    [Fact]
+    public void CountryCode_ReturnsBH() => _validator.CountryCode.Should().Be("BH");
+
+    [Theory]
+    [InlineData("BH67BMAG00001299123456")]
+    public void IsValidIban_WithValidBahrainIbans_ReturnsTrue(string iban)
+        => _validator.Validate(iban).IsValid.Should().BeTrue();
+
+    [Theory]
+    [InlineData("BH67 BMAG 0000 1299 1234 56")] // With spaces
+    [InlineData("bh67bmag00001299123456")] // Lowercase
+    public void IsValidIban_WithFormattedIbans_ReturnsTrue(string iban)
+        => _validator.Validate(iban).IsValid.Should().BeTrue();
+
+    [Theory]
+    [InlineData("BH00BMAG00001299123456")] // Wrong check digits
+    [InlineData("DE89370400440532013000")] // Wrong country
+    [InlineData("BH67BMAG000012991234")] // Too short
+    [InlineData("BH67BMAG000012991234567890")] // Too long
+    [InlineData("")] // Empty
+    [InlineData(null)] // Null
+    public void IsValidIban_WithInvalidIbans_ReturnsFalse(string? iban)
+        => _validator.Validate(iban).IsValid.Should().BeFalse();
+
+    [Theory]
+    [InlineData("BH67BMAG00001299123456")]
+    public void ValidateBahrainIban_WithValidIbans_ReturnsTrue(string iban)
+        => BahrainIbanValidator.ValidateBahrainIban(iban).IsValid.Should().BeTrue();
+}

--- a/tests/Finova.Tests/Countries/MiddleEast/Israel/Validators/IsraelIbanValidatorTests.cs
+++ b/tests/Finova.Tests/Countries/MiddleEast/Israel/Validators/IsraelIbanValidatorTests.cs
@@ -1,0 +1,39 @@
+using Finova.Countries.MiddleEast.Israel.Validators;
+using FluentAssertions;
+using Xunit;
+
+namespace Finova.Tests.Countries.MiddleEast.Israel.Validators;
+
+public class IsraelIbanValidatorTests
+{
+    private readonly IsraelIbanValidator _validator = new();
+
+    [Fact]
+    public void CountryCode_ReturnsIL() => _validator.CountryCode.Should().Be("IL");
+
+    [Theory]
+    [InlineData("IL620108000000099999999")]
+    public void IsValidIban_WithValidIsraelIbans_ReturnsTrue(string iban)
+        => _validator.Validate(iban).IsValid.Should().BeTrue();
+
+    [Theory]
+    [InlineData("IL62 0108 0000 0009 9999 999")] // With spaces
+    [InlineData("il620108000000099999999")] // Lowercase
+    public void IsValidIban_WithFormattedIbans_ReturnsTrue(string iban)
+        => _validator.Validate(iban).IsValid.Should().BeTrue();
+
+    [Theory]
+    [InlineData("IL000108000000099999999")] // Wrong check digits
+    [InlineData("DE89370400440532013000")] // Wrong country
+    [InlineData("IL62010800000009999")] // Too short
+    [InlineData("IL620108000000099999999999")] // Too long
+    [InlineData("")] // Empty
+    [InlineData(null)] // Null
+    public void IsValidIban_WithInvalidIbans_ReturnsFalse(string? iban)
+        => _validator.Validate(iban).IsValid.Should().BeFalse();
+
+    [Theory]
+    [InlineData("IL620108000000099999999")]
+    public void ValidateIsraelIban_WithValidIbans_ReturnsTrue(string iban)
+        => IsraelIbanValidator.ValidateIsraelIban(iban).IsValid.Should().BeTrue();
+}

--- a/tests/Finova.Tests/Countries/MiddleEast/Jordan/Validators/JordanIbanValidatorTests.cs
+++ b/tests/Finova.Tests/Countries/MiddleEast/Jordan/Validators/JordanIbanValidatorTests.cs
@@ -1,0 +1,39 @@
+using Finova.Countries.MiddleEast.Jordan.Validators;
+using FluentAssertions;
+using Xunit;
+
+namespace Finova.Tests.Countries.MiddleEast.Jordan.Validators;
+
+public class JordanIbanValidatorTests
+{
+    private readonly JordanIbanValidator _validator = new();
+
+    [Fact]
+    public void CountryCode_ReturnsJO() => _validator.CountryCode.Should().Be("JO");
+
+    [Theory]
+    [InlineData("JO94CBJO0010000000000131000302")]
+    public void IsValidIban_WithValidJordanIbans_ReturnsTrue(string iban)
+        => _validator.Validate(iban).IsValid.Should().BeTrue();
+
+    [Theory]
+    [InlineData("JO94 CBJO 0010 0000 0000 0131 0003 02")] // With spaces
+    [InlineData("jo94cbjo0010000000000131000302")] // Lowercase
+    public void IsValidIban_WithFormattedIbans_ReturnsTrue(string iban)
+        => _validator.Validate(iban).IsValid.Should().BeTrue();
+
+    [Theory]
+    [InlineData("JO00CBJO0010000000000131000302")] // Wrong check digits
+    [InlineData("DE89370400440532013000")] // Wrong country
+    [InlineData("JO94CBJO00100000000001310003")] // Too short
+    [InlineData("JO94CBJO001000000000013100030299")] // Too long
+    [InlineData("")] // Empty
+    [InlineData(null)] // Null
+    public void IsValidIban_WithInvalidIbans_ReturnsFalse(string? iban)
+        => _validator.Validate(iban).IsValid.Should().BeFalse();
+
+    [Theory]
+    [InlineData("JO94CBJO0010000000000131000302")]
+    public void ValidateJordanIban_WithValidIbans_ReturnsTrue(string iban)
+        => JordanIbanValidator.ValidateJordanIban(iban).IsValid.Should().BeTrue();
+}

--- a/tests/Finova.Tests/Countries/MiddleEast/Kuwait/Validators/KuwaitIbanValidatorTests.cs
+++ b/tests/Finova.Tests/Countries/MiddleEast/Kuwait/Validators/KuwaitIbanValidatorTests.cs
@@ -1,0 +1,39 @@
+using Finova.Countries.MiddleEast.Kuwait.Validators;
+using FluentAssertions;
+using Xunit;
+
+namespace Finova.Tests.Countries.MiddleEast.Kuwait.Validators;
+
+public class KuwaitIbanValidatorTests
+{
+    private readonly KuwaitIbanValidator _validator = new();
+
+    [Fact]
+    public void CountryCode_ReturnsKW() => _validator.CountryCode.Should().Be("KW");
+
+    [Theory]
+    [InlineData("KW81CBKU0000000000001234560101")]
+    public void IsValidIban_WithValidKuwaitIbans_ReturnsTrue(string iban)
+        => _validator.Validate(iban).IsValid.Should().BeTrue();
+
+    [Theory]
+    [InlineData("KW81 CBKU 0000 0000 0000 1234 5601 01")] // With spaces
+    [InlineData("kw81cbku0000000000001234560101")] // Lowercase
+    public void IsValidIban_WithFormattedIbans_ReturnsTrue(string iban)
+        => _validator.Validate(iban).IsValid.Should().BeTrue();
+
+    [Theory]
+    [InlineData("KW00CBKU0000000000001234560101")] // Wrong check digits
+    [InlineData("DE89370400440532013000")] // Wrong country
+    [InlineData("KW81CBKU000000000000123456")] // Too short
+    [InlineData("KW81CBKU000000000000123456010199")] // Too long
+    [InlineData("")] // Empty
+    [InlineData(null)] // Null
+    public void IsValidIban_WithInvalidIbans_ReturnsFalse(string? iban)
+        => _validator.Validate(iban).IsValid.Should().BeFalse();
+
+    [Theory]
+    [InlineData("KW81CBKU0000000000001234560101")]
+    public void ValidateKuwaitIban_WithValidIbans_ReturnsTrue(string iban)
+        => KuwaitIbanValidator.ValidateKuwaitIban(iban).IsValid.Should().BeTrue();
+}

--- a/tests/Finova.Tests/Countries/MiddleEast/Lebanon/Validators/LebanonIbanValidatorTests.cs
+++ b/tests/Finova.Tests/Countries/MiddleEast/Lebanon/Validators/LebanonIbanValidatorTests.cs
@@ -1,0 +1,39 @@
+using Finova.Countries.MiddleEast.Lebanon.Validators;
+using FluentAssertions;
+using Xunit;
+
+namespace Finova.Tests.Countries.MiddleEast.Lebanon.Validators;
+
+public class LebanonIbanValidatorTests
+{
+    private readonly LebanonIbanValidator _validator = new();
+
+    [Fact]
+    public void CountryCode_ReturnsLB() => _validator.CountryCode.Should().Be("LB");
+
+    [Theory]
+    [InlineData("LB62099900000001001901229114")]
+    public void IsValidIban_WithValidLebanonIbans_ReturnsTrue(string iban)
+        => _validator.Validate(iban).IsValid.Should().BeTrue();
+
+    [Theory]
+    [InlineData("LB62 0999 0000 0001 0019 0122 9114")] // With spaces
+    [InlineData("lb62099900000001001901229114")] // Lowercase
+    public void IsValidIban_WithFormattedIbans_ReturnsTrue(string iban)
+        => _validator.Validate(iban).IsValid.Should().BeTrue();
+
+    [Theory]
+    [InlineData("LB00099900000001001901229114")] // Wrong check digits
+    [InlineData("DE89370400440532013000")] // Wrong country
+    [InlineData("LB6209990000000100190122")] // Too short
+    [InlineData("LB6209990000000100190122911499")] // Too long
+    [InlineData("")] // Empty
+    [InlineData(null)] // Null
+    public void IsValidIban_WithInvalidIbans_ReturnsFalse(string? iban)
+        => _validator.Validate(iban).IsValid.Should().BeFalse();
+
+    [Theory]
+    [InlineData("LB62099900000001001901229114")]
+    public void ValidateLebanonIban_WithValidIbans_ReturnsTrue(string iban)
+        => LebanonIbanValidator.ValidateLebanonIban(iban).IsValid.Should().BeTrue();
+}

--- a/tests/Finova.Tests/Countries/MiddleEast/Qatar/Validators/QatarIbanValidatorTests.cs
+++ b/tests/Finova.Tests/Countries/MiddleEast/Qatar/Validators/QatarIbanValidatorTests.cs
@@ -1,0 +1,39 @@
+using Finova.Countries.MiddleEast.Qatar.Validators;
+using FluentAssertions;
+using Xunit;
+
+namespace Finova.Tests.Countries.MiddleEast.Qatar.Validators;
+
+public class QatarIbanValidatorTests
+{
+    private readonly QatarIbanValidator _validator = new();
+
+    [Fact]
+    public void CountryCode_ReturnsQA() => _validator.CountryCode.Should().Be("QA");
+
+    [Theory]
+    [InlineData("QA58DOHB00001234567890ABCDEFG")]
+    public void IsValidIban_WithValidQatarIbans_ReturnsTrue(string iban)
+        => _validator.Validate(iban).IsValid.Should().BeTrue();
+
+    [Theory]
+    [InlineData("QA58 DOHB 0000 1234 5678 90AB CDEF G")] // With spaces
+    [InlineData("qa58dohb00001234567890abcdefg")] // Lowercase
+    public void IsValidIban_WithFormattedIbans_ReturnsTrue(string iban)
+        => _validator.Validate(iban).IsValid.Should().BeTrue();
+
+    [Theory]
+    [InlineData("QA00DOHB00001234567890ABCDEFG")] // Wrong check digits
+    [InlineData("DE89370400440532013000")] // Wrong country
+    [InlineData("QA58DOHB00001234567890ABC")] // Too short
+    [InlineData("QA58DOHB00001234567890ABCDEFGH99")] // Too long
+    [InlineData("")] // Empty
+    [InlineData(null)] // Null
+    public void IsValidIban_WithInvalidIbans_ReturnsFalse(string? iban)
+        => _validator.Validate(iban).IsValid.Should().BeFalse();
+
+    [Theory]
+    [InlineData("QA58DOHB00001234567890ABCDEFG")]
+    public void ValidateQatarIban_WithValidIbans_ReturnsTrue(string iban)
+        => QatarIbanValidator.ValidateQatarIban(iban).IsValid.Should().BeTrue();
+}

--- a/tests/Finova.Tests/Countries/MiddleEast/SaudiArabia/Validators/SaudiArabiaIbanValidatorTests.cs
+++ b/tests/Finova.Tests/Countries/MiddleEast/SaudiArabia/Validators/SaudiArabiaIbanValidatorTests.cs
@@ -1,0 +1,39 @@
+using Finova.Countries.MiddleEast.SaudiArabia.Validators;
+using FluentAssertions;
+using Xunit;
+
+namespace Finova.Tests.Countries.MiddleEast.SaudiArabia.Validators;
+
+public class SaudiArabiaIbanValidatorTests
+{
+    private readonly SaudiArabiaIbanValidator _validator = new();
+
+    [Fact]
+    public void CountryCode_ReturnsSA() => _validator.CountryCode.Should().Be("SA");
+
+    [Theory]
+    [InlineData("SA0380000000608010167519")]
+    public void IsValidIban_WithValidSaudiArabiaIbans_ReturnsTrue(string iban)
+        => _validator.Validate(iban).IsValid.Should().BeTrue();
+
+    [Theory]
+    [InlineData("SA03 8000 0000 6080 1016 7519")] // With spaces
+    [InlineData("sa0380000000608010167519")] // Lowercase
+    public void IsValidIban_WithFormattedIbans_ReturnsTrue(string iban)
+        => _validator.Validate(iban).IsValid.Should().BeTrue();
+
+    [Theory]
+    [InlineData("SA0080000000608010167519")] // Wrong check digits
+    [InlineData("DE89370400440532013000")] // Wrong country
+    [InlineData("SA038000000060801016")] // Too short
+    [InlineData("SA038000000060801016751999")] // Too long
+    [InlineData("")] // Empty
+    [InlineData(null)] // Null
+    public void IsValidIban_WithInvalidIbans_ReturnsFalse(string? iban)
+        => _validator.Validate(iban).IsValid.Should().BeFalse();
+
+    [Theory]
+    [InlineData("SA0380000000608010167519")]
+    public void ValidateSaudiArabiaIban_WithValidIbans_ReturnsTrue(string iban)
+        => SaudiArabiaIbanValidator.ValidateSaudiArabiaIban(iban).IsValid.Should().BeTrue();
+}

--- a/tests/Finova.Tests/Countries/MiddleEast/UAE/Validators/UAEIbanValidatorTests.cs
+++ b/tests/Finova.Tests/Countries/MiddleEast/UAE/Validators/UAEIbanValidatorTests.cs
@@ -1,0 +1,39 @@
+using Finova.Countries.MiddleEast.UAE.Validators;
+using FluentAssertions;
+using Xunit;
+
+namespace Finova.Tests.Countries.MiddleEast.UAE.Validators;
+
+public class UAEIbanValidatorTests
+{
+    private readonly UAEIbanValidator _validator = new();
+
+    [Fact]
+    public void CountryCode_ReturnsAE() => _validator.CountryCode.Should().Be("AE");
+
+    [Theory]
+    [InlineData("AE070331234567890123456")]
+    public void IsValidIban_WithValidUAEIbans_ReturnsTrue(string iban)
+        => _validator.Validate(iban).IsValid.Should().BeTrue();
+
+    [Theory]
+    [InlineData("AE07 0331 2345 6789 0123 456")] // With spaces
+    [InlineData("ae070331234567890123456")] // Lowercase
+    public void IsValidIban_WithFormattedIbans_ReturnsTrue(string iban)
+        => _validator.Validate(iban).IsValid.Should().BeTrue();
+
+    [Theory]
+    [InlineData("AE000331234567890123456")] // Wrong check digits
+    [InlineData("DE89370400440532013000")] // Wrong country
+    [InlineData("AE07033123456789012")] // Too short
+    [InlineData("AE07033123456789012345699")] // Too long
+    [InlineData("")] // Empty
+    [InlineData(null)] // Null
+    public void IsValidIban_WithInvalidIbans_ReturnsFalse(string? iban)
+        => _validator.Validate(iban).IsValid.Should().BeFalse();
+
+    [Theory]
+    [InlineData("AE070331234567890123456")]
+    public void ValidateUAEIban_WithValidIbans_ReturnsTrue(string iban)
+        => UAEIbanValidator.ValidateUAEIban(iban).IsValid.Should().BeTrue();
+}

--- a/tests/Finova.Tests/Services/Global/GlobalIbanValidatorTests.cs
+++ b/tests/Finova.Tests/Services/Global/GlobalIbanValidatorTests.cs
@@ -1,0 +1,87 @@
+using Finova.Services;
+using FluentAssertions;
+using Xunit;
+
+namespace Finova.Tests.Services.Global;
+
+public class GlobalIbanValidatorTests
+{
+    #region European IBANs
+    [Theory]
+    [InlineData("DE89370400440532013000")] // Germany
+    [InlineData("FR7630006000011234567890189")] // France
+    [InlineData("GB82WEST12345698765432")] // United Kingdom
+    [InlineData("ES9121000418450200051332")] // Spain
+    [InlineData("IT60X0542811101000000123456")] // Italy
+    [InlineData("NL91ABNA0417164300")] // Netherlands
+    [InlineData("BE68539007547034")] // Belgium
+    [InlineData("AT611904300234573201")] // Austria
+    [InlineData("CH9300762011623852957")] // Switzerland
+    [InlineData("PL61109010140000071219812874")] // Poland
+    public void ValidateIban_WithValidEuropeanIbans_ReturnsTrue(string iban)
+        => GlobalIbanValidator.ValidateIban(iban).IsValid.Should().BeTrue();
+    #endregion
+
+    #region Middle East IBANs
+    [Theory]
+    [InlineData("BH67BMAG00001299123456")] // Bahrain
+    [InlineData("IL620108000000099999999")] // Israel
+    [InlineData("JO94CBJO0010000000000131000302")] // Jordan
+    [InlineData("KW81CBKU0000000000001234560101")] // Kuwait
+    [InlineData("LB62099900000001001901229114")] // Lebanon
+    [InlineData("QA58DOHB00001234567890ABCDEFG")] // Qatar
+    [InlineData("SA0380000000608010167519")] // Saudi Arabia
+    [InlineData("AE070331234567890123456")] // UAE
+    public void ValidateIban_WithValidMiddleEastIbans_ReturnsTrue(string iban)
+        => GlobalIbanValidator.ValidateIban(iban).IsValid.Should().BeTrue();
+    #endregion
+
+    #region Africa IBANs
+    [Theory]
+    [InlineData("EG380019000500000000263180002")] // Egypt
+    [InlineData("MR1300020001010000123456753")] // Mauritania
+    public void ValidateIban_WithValidAfricaIbans_ReturnsTrue(string iban)
+        => GlobalIbanValidator.ValidateIban(iban).IsValid.Should().BeTrue();
+    #endregion
+
+    #region Americas IBANs
+    [Theory]
+    [InlineData("BR1800360305000010009795493C1")] // Brazil
+    [InlineData("CR05015202001026284066")] // Costa Rica
+    [InlineData("DO22ACAU00000000000123456789")] // Dominican Republic
+    [InlineData("SV62CENR00000000000000700025")] // El Salvador
+    [InlineData("GT82TRAJ01020000001210029690")] // Guatemala
+    [InlineData("VG96VPVG0000012345678901")] // Virgin Islands British
+    public void ValidateIban_WithValidAmericasIbans_ReturnsTrue(string iban)
+        => GlobalIbanValidator.ValidateIban(iban).IsValid.Should().BeTrue();
+    #endregion
+
+    #region Asia IBANs
+    [Theory]
+    [InlineData("KZ86125KZT5004100100")] // Kazakhstan
+    [InlineData("PK36SCBL0000001123456702")] // Pakistan
+    [InlineData("TL380080012345678910157")] // Timor-Leste
+    public void ValidateIban_WithValidAsiaIbans_ReturnsTrue(string iban)
+        => GlobalIbanValidator.ValidateIban(iban).IsValid.Should().BeTrue();
+    #endregion
+
+    #region Invalid IBANs
+    [Theory]
+    [InlineData("XX89370400440532013000")] // Invalid country code
+    [InlineData("DE00370400440532013000")] // Wrong check digits
+    [InlineData("DE8937040044053201")] // Too short
+    [InlineData("")] // Empty
+    [InlineData(null)] // Null
+    public void ValidateIban_WithInvalidIbans_ReturnsFalse(string? iban)
+        => GlobalIbanValidator.ValidateIban(iban).IsValid.Should().BeFalse();
+    #endregion
+
+    #region Formatted IBANs
+    [Theory]
+    [InlineData("DE89 3704 0044 0532 0130 00")] // With spaces
+    [InlineData("de89370400440532013000")] // Lowercase
+    [InlineData("  DE89370400440532013000  ")] // With leading/trailing spaces
+    public void ValidateIban_WithFormattedIbans_ReturnsTrue(string iban)
+        => GlobalIbanValidator.ValidateIban(iban).IsValid.Should().BeTrue();
+    #endregion
+}


### PR DESCRIPTION
- Implemented Mauritania IBAN validator tests.
- Implemented Brazil IBAN validator tests.
- Implemented Costa Rica IBAN validator tests.
- Implemented Dominican Republic IBAN validator tests.
- Implemented El Salvador IBAN validator tests.
- Implemented Guatemala IBAN validator tests.
- Implemented Virgin Islands British IBAN validator tests.
- Implemented Kazakhstan IBAN validator tests.
- Implemented Pakistan IBAN validator tests.
- Implemented Timor Leste IBAN validator tests.
- Implemented Bahrain IBAN validator tests.
- Implemented Israel IBAN validator tests.
- Implemented Jordan IBAN validator tests.
- Implemented Kuwait IBAN validator tests.
- Implemented Lebanon IBAN validator tests.
- Implemented Qatar IBAN validator tests.
- Implemented Saudi Arabia IBAN validator tests.
- Implemented UAE IBAN validator tests.
- Added global IBAN validation tests for various regions including Europe, Middle East, Africa, Americas, and Asia.
- Included tests for valid and invalid IBAN formats.